### PR TITLE
[GUI-144] Add concurrency chart.

### DIFF
--- a/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
+++ b/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
@@ -51,8 +51,7 @@ export class MongooseConcurrencyChart implements MongooseChart {
     }
 
     updateChart(recordLoadStepId: string, metrics: ChartPoint[]) {
-
-        this.chartData[0].data = metrics;
+        this.chartData[this.LAST_CONCURRENT_METRICS_DATASET_INDEX].data = metrics;
         let labels: string[] = [];
         for (var chartPoint of metrics) { 
             let timestamp = chartPoint.getX() as unknown; 

--- a/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
+++ b/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
@@ -3,12 +3,12 @@ import { MongooseChartDao } from "../mongoose-chart-interface/mongoose-chart-dao
 import { MongooseTestChartDataset } from "../mongoose-chart-interface/mongoose-test-chart-dataset.model";
 import { ChartPoint } from "../mongoose-chart-interface/chart-point.model";
 import { MongooseChart } from "../mongoose-chart-interface/mongoose-chart.interface";
-import { NumbericMetricValueType } from "../mongoose-chart-interface/numeric-metric-value-type";
+import { NumericMetricValueType } from "../mongoose-chart-interface/numeric-metric-value-type";
 
 /**
  * Concurrency chart for BasicChart component.
  */
-export class MongooseConcurrencyChart implements MongooseChart { 
+export class MongooseConcurrencyChart implements MongooseChart {
 
     /**
      * Make sure to update @param LAST_CONCURRENT_METRICS_DATASET_INDEX, @param MEAN_CONCURRENT_METRICS_DATASET_INDEX in case ...
@@ -51,25 +51,25 @@ export class MongooseConcurrencyChart implements MongooseChart {
         this.configureChartOptions();
     }
 
-    updateChart(recordLoadStepId: string, metrics: ChartPoint[], numericMetricValueType: NumbericMetricValueType) {
-        let chartIndex: number = undefined; 
-        switch (numericMetricValueType) { 
-            case (NumbericMetricValueType.LAST): { 
+    updateChart(recordLoadStepId: string, metrics: ChartPoint[], numericMetricValueType: NumericMetricValueType) {
+        let chartIndex: number = undefined;
+        switch (numericMetricValueType) {
+            case (NumericMetricValueType.LAST): {
                 chartIndex = this.LAST_CONCURRENT_METRICS_DATASET_INDEX;
                 break;
             }
-            case (NumbericMetricValueType.MEAN): { 
+            case (NumericMetricValueType.MEAN): {
                 chartIndex = this.MEAN_CONCURRENT_METRICS_DATASET_INDEX;
                 break;
             }
-            default: { 
+            default: {
                 throw new Error(`Unable to find specified metric type ${numericMetricValueType} for Concurrency chart.`);
             }
         }
         this.chartData[chartIndex].data = metrics;
         let labels: string[] = [];
-        for (var chartPoint of metrics) { 
-            let timestamp = chartPoint.getX() as unknown; 
+        for (var chartPoint of metrics) {
+            let timestamp = chartPoint.getX() as unknown;
             labels.push(timestamp as string);
         }
         this.chartLabels = labels;
@@ -89,7 +89,7 @@ export class MongooseConcurrencyChart implements MongooseChart {
     private configureChartOptions() {
         const mediumBlueColorRgb: string = "rgb(0,0,205)";
         this.chartData[this.LAST_CONCURRENT_METRICS_DATASET_INDEX].setChartColor(mediumBlueColorRgb);
-       
+
         let chartTitle: string = "Mongoose's concurrent operations";
         this.chartOptions.setChartTitle(chartTitle);
     }

--- a/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
+++ b/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
@@ -87,9 +87,9 @@ export class MongooseConcurrencyChart implements MongooseChart {
     }
 
     private configureChartOptions() {
-
-        let lightRedColorRgb: string = "rgb(255, 0, 0)";
-        this.chartData[0].setChartColor(lightRedColorRgb);
+        const mediumBlueColorRgb: string = "rgb(0,0,205)";
+        this.chartData[this.LAST_CONCURRENT_METRICS_DATASET_INDEX].setChartColor(mediumBlueColorRgb);
+       
         let chartTitle: string = "Mongoose's concurrent operations";
         this.chartOptions.setChartTitle(chartTitle);
     }

--- a/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
+++ b/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
@@ -1,8 +1,5 @@
 import { MongooseChartOptions } from "../mongoose-chart-interface/mongoose-chart-options";
 import { MongooseChartDao } from "../mongoose-chart-interface/mongoose-chart-dao.model";
-import { MongooseMetric } from "../mongoose-metric.model";
-import { InternalMetricNames } from "../internal-metric-names";
-import { formatDate } from "@angular/common";
 import { MongooseTestChartDataset } from "../mongoose-chart-interface/mongoose-test-chart-dataset.model";
 import { ChartPoint } from "../mongoose-chart-interface/chart-point.model";
 import { MongooseChart } from "../mongoose-chart-interface/mongoose-chart.interface";
@@ -11,6 +8,16 @@ import { MongooseChart } from "../mongoose-chart-interface/mongoose-chart.interf
  * Concurrency chart for BasicChart component.
  */
 export class MongooseConcurrencyChart implements MongooseChart { 
+
+    /**
+     * Make sure to update @param LAST_CONCURRENT_METRICS_DATASET_INDEX, @param MEAN_CONCURRENT_METRICS_DATASET_INDEX in case ...
+     * ... @param chartData order changes.
+     * @param LAST_CONCURRENT_METRICS_DATASET_INDEX index of data array for "concurrent_last" metrics chart
+     * @param MEAN_CONCURRENT_METRICS_DATASET_INDEX index of data array for "concurrent_mean" metrics chart
+     */
+    private readonly LAST_CONCURRENT_METRICS_DATASET_INDEX = 0;
+    private readonly MEAN_CONCURRENT_METRICS_DATASET_INDEX = 1;
+
     chartOptions: MongooseChartOptions;
     chartLabels: string[];
     chartType: string;
@@ -32,9 +39,11 @@ export class MongooseConcurrencyChart implements MongooseChart {
         this.shouldShiftChart = shouldShiftChart;
 
         let concurrencyLastDatasetInitialValue = new MongooseTestChartDataset([], 'Concurrency, last');
+        let concurrentMeanDatasetInitialValue = new MongooseTestChartDataset([], "Concurrent, mean");
 
         var concurrencyChartDataset: MongooseTestChartDataset[] = [];
         concurrencyChartDataset.push(concurrencyLastDatasetInitialValue);
+        concurrencyChartDataset.push(concurrentMeanDatasetInitialValue);
 
         this.chartData = concurrencyChartDataset;
 
@@ -49,17 +58,6 @@ export class MongooseConcurrencyChart implements MongooseChart {
             let timestamp = chartPoint.getX() as unknown; 
             labels.push(timestamp as string);
         }
-        // var concurrencyLastMetrics: any[] = [];
-
-        // var updatedLabels: any[] = [];
-
-        // let metricName = InternalMetricNames.MEAN_DURATION;
-        // metrics.forEach(concurrencyMetric => {
-        //     metricName = concurrencyMetric.getName();
-        //     let durationMetricValue = concurrencyMetric.getValue();
-            
-        //     updatedLabels.push(formatDate(Math.round(concurrencyMetric.getTimestamp() * 1000), 'mediumTime', 'en-US'));
-        // });
         this.chartLabels = labels;
 
 

--- a/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
+++ b/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
@@ -5,16 +5,18 @@ import { InternalMetricNames } from "../internal-metric-names";
 import { formatDate } from "@angular/common";
 import { MongooseTestChartDataset } from "../mongoose-chart-interface/mongoose-test-chart-dataset.model";
 import { ChartPoint } from "../mongoose-chart-interface/chart-point.model";
+import { MongooseChart } from "../mongoose-chart-interface/mongoose-chart.interface";
 
 /**
  * Concurrency chart for BasicChart component.
  */
-export class MongooseConcurrencyChart { 
+export class MongooseConcurrencyChart implements MongooseChart { 
     chartOptions: MongooseChartOptions;
     chartLabels: string[];
     chartType: string;
     chartLegend: boolean;
     chartData: MongooseTestChartDataset[];
+
     mongooseChartDao: MongooseChartDao;
     isChartDataValid: boolean;
     shouldShiftChart: boolean;
@@ -39,11 +41,11 @@ export class MongooseConcurrencyChart {
         this.configureChartOptions();
     }
 
-    updateChart(recordLoadStepId: string, chartPoints: ChartPoint[]) {
+    updateChart(recordLoadStepId: string, metrics: ChartPoint[]) {
 
-        this.chartData[0].points = chartPoints;
+        this.chartData[0].points = metrics;
         let labels: string[] = [];
-        for (var chartPoint of chartPoints) { 
+        for (var chartPoint of metrics) { 
             let timestamp = chartPoint.getX() as unknown; 
             labels.push(timestamp as string);
         }

--- a/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
+++ b/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
@@ -3,6 +3,7 @@ import { MongooseChartDao } from "../mongoose-chart-interface/mongoose-chart-dao
 import { MongooseTestChartDataset } from "../mongoose-chart-interface/mongoose-test-chart-dataset.model";
 import { ChartPoint } from "../mongoose-chart-interface/chart-point.model";
 import { MongooseChart } from "../mongoose-chart-interface/mongoose-chart.interface";
+import { NumbericMetricValueType } from "../mongoose-chart-interface/numeric-metric-value-type";
 
 /**
  * Concurrency chart for BasicChart component.
@@ -50,8 +51,22 @@ export class MongooseConcurrencyChart implements MongooseChart {
         this.configureChartOptions();
     }
 
-    updateChart(recordLoadStepId: string, metrics: ChartPoint[]) {
-        this.chartData[this.LAST_CONCURRENT_METRICS_DATASET_INDEX].data = metrics;
+    updateChart(recordLoadStepId: string, metrics: ChartPoint[], numericMetricValueType: NumbericMetricValueType) {
+        let chartIndex: number = undefined; 
+        switch (numericMetricValueType) { 
+            case (NumbericMetricValueType.LAST): { 
+                chartIndex = this.LAST_CONCURRENT_METRICS_DATASET_INDEX;
+                break;
+            }
+            case (NumbericMetricValueType.MEAN): { 
+                chartIndex = this.MEAN_CONCURRENT_METRICS_DATASET_INDEX;
+                break;
+            }
+            default: { 
+                throw new Error(`Unable to find specified metric type ${numericMetricValueType} for Concurrency chart.`);
+            }
+        }
+        this.chartData[chartIndex].data = metrics;
         let labels: string[] = [];
         for (var chartPoint of metrics) { 
             let timestamp = chartPoint.getX() as unknown; 

--- a/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
+++ b/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
@@ -1,0 +1,79 @@
+import { MongooseChartOptions } from "../mongoose-chart-interface/mongoose-chart-options";
+import { MongooseChartDao } from "../mongoose-chart-interface/mongoose-chart-dao.model";
+import { MongooseMetric } from "../mongoose-metric.model";
+import { InternalMetricNames } from "../internal-metric-names";
+import { formatDate } from "@angular/common";
+import { MongooseTestChartDataset } from "../mongoose-chart-interface/mongoose-test-chart-dataset.model";
+import { ChartPoint } from "../mongoose-chart-interface/chart-point.model";
+
+/**
+ * Concurrency chart for BasicChart component.
+ */
+export class MongooseConcurrencyChart { 
+    chartOptions: MongooseChartOptions;
+    chartLabels: string[];
+    chartType: string;
+    chartLegend: boolean;
+    chartData: MongooseTestChartDataset[];
+    mongooseChartDao: MongooseChartDao;
+    isChartDataValid: boolean;
+    shouldShiftChart: boolean;
+
+
+    constructor(chartOptions: MongooseChartOptions, chartLabels: string[], chartType: string, chartLegend: boolean, mongooseChartDao: MongooseChartDao, shouldShiftChart: boolean = false) {
+        this.chartOptions = chartOptions;
+        this.chartLabels = chartLabels;
+        this.chartType = chartType;
+        this.chartLegend = chartLegend;
+        this.mongooseChartDao = mongooseChartDao;
+        this.isChartDataValid = true;
+        this.shouldShiftChart = shouldShiftChart;
+
+        let concurrencyLastDatasetInitialValue = new MongooseTestChartDataset([], 'Concurrency, last');
+
+        var concurrencyChartDataset: MongooseTestChartDataset[] = [];
+        concurrencyChartDataset.push(concurrencyLastDatasetInitialValue);
+
+        this.chartData = concurrencyChartDataset;
+
+        this.configureChartOptions();
+    }
+
+    updateChart(recordLoadStepId: string, chartPoints: ChartPoint[]) {
+
+        this.chartData[0].points = chartPoints;
+        let labels: string[] = [];
+        for (var chartPoint of chartPoints) { 
+            let timestamp = chartPoint.getX() as unknown; 
+            labels.push(timestamp as string);
+        }
+        // var concurrencyLastMetrics: any[] = [];
+
+        // var updatedLabels: any[] = [];
+
+        // let metricName = InternalMetricNames.MEAN_DURATION;
+        // metrics.forEach(concurrencyMetric => {
+        //     metricName = concurrencyMetric.getName();
+        //     let durationMetricValue = concurrencyMetric.getValue();
+            
+        //     updatedLabels.push(formatDate(Math.round(concurrencyMetric.getTimestamp() * 1000), 'mediumTime', 'en-US'));
+        // });
+        this.chartLabels = labels;
+
+
+    }
+
+    public shouldDrawChart(): boolean {
+        return this.isChartDataValid;
+    }
+
+    private shouldScaleChart(): boolean {
+        const maxAmountOfPointsInGraph = 20;
+        return ((this.chartLabels.length >= maxAmountOfPointsInGraph) && this.shouldShiftChart);
+    }
+
+    private configureChartOptions() {
+        let chartTitle: string = "Mongoose's concurrent operations";
+        this.chartOptions.setChartTitle(chartTitle);
+    }
+}

--- a/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
+++ b/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
@@ -43,7 +43,7 @@ export class MongooseConcurrencyChart implements MongooseChart {
 
     updateChart(recordLoadStepId: string, metrics: ChartPoint[]) {
 
-        this.chartData[0].points = metrics;
+        this.chartData[0].data = metrics;
         let labels: string[] = [];
         for (var chartPoint of metrics) { 
             let timestamp = chartPoint.getX() as unknown; 
@@ -75,6 +75,9 @@ export class MongooseConcurrencyChart implements MongooseChart {
     }
 
     private configureChartOptions() {
+
+        let lightRedColorRgb: string = "rgb(255, 0, 0)";
+        this.chartData[0].setChartColor(lightRedColorRgb);
         let chartTitle: string = "Mongoose's concurrent operations";
         this.chartOptions.setChartTitle(chartTitle);
     }

--- a/console/src/app/core/models/chart/internal-metric-names.ts
+++ b/console/src/app/core/models/chart/internal-metric-names.ts
@@ -3,6 +3,8 @@
  * ... names of metrics within third-party services like Prometheus.
  */
 export class InternalMetricNames { 
+    static readonly CONCURRENCY_LAST = "concurrency_last";
+    
     static readonly LATENCY_MAX = "latency_max";
     static readonly LATENCY_MIN = "latency_min";    
     static readonly LATENCY_MEAN = "latency_mean";

--- a/console/src/app/core/models/chart/mongoose-chart-interface/chart-point.model.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/chart-point.model.ts
@@ -6,4 +6,8 @@ export class ChartPoint {
         this.x = x; 
         this.y = y;
     }
+
+    public getX(): number { 
+        return this.x; 
+    }
 }

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-dao.model.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-dao.model.ts
@@ -4,7 +4,7 @@ import { MongooseMetric } from '../mongoose-metric.model';
 import { map } from 'rxjs/operators';
 import { InternalMetricNames } from '../internal-metric-names';
 import { MetricValueType } from './metric-value-type';
-import { NumbericMetricValueType } from './numeric-metric-value-type';
+import { NumericMetricValueType } from './numeric-metric-value-type';
 import { ChartPoint } from './chart-point.model';
 
 /**
@@ -45,7 +45,7 @@ export class MongooseChartDao {
         );
     }
 
-    public getConcurrencyChartPoints(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<ChartPoint[]> {
+    public getConcurrencyChartPoints(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumericMetricValueType): Observable<ChartPoint[]> {
         let concurrencyMetrics$: Observable<MongooseMetric[]> = this.chartDataProvider.getConcurrency(periodInSeconds, loadStepId, numericMetricValueType);
         let elapsedTimeValues$: Observable<MongooseMetric[]> = this.chartDataProvider.getElapsedTimeValue(periodInSeconds, loadStepId);
 
@@ -113,16 +113,16 @@ export class MongooseChartDao {
      * @param numericMetricValueType for bandwidth can be LAST (mean the last gathered) or MEAN (mean value).
      * @returns observable array of bandwidth metrics matched to requested parameters.
      */
-    public getBandWidth(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]> {
+    public getBandWidth(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumericMetricValueType): Observable<MongooseMetric[]> {
         return this.chartDataProvider.getBandWidth(periodInSeconds, loadStepId, numericMetricValueType).pipe(
             map((metrics: MongooseMetric[]) => {
                 var internalMetricName: string = undefined;
                 switch (numericMetricValueType) {
-                    case (NumbericMetricValueType.LAST): {
+                    case (NumericMetricValueType.LAST): {
                         internalMetricName = InternalMetricNames.BANDWIDTH_LAST;
                         break;
                     }
-                    case (NumbericMetricValueType.MEAN): {
+                    case (NumericMetricValueType.MEAN): {
                         internalMetricName = InternalMetricNames.BANDWIDTH_MEAN;
                         break;
                     }
@@ -144,16 +144,16 @@ export class MongooseChartDao {
     * @param numericMetricValueType for bandwidth can be LAST (mean the last gathered) or MEAN (mean value).
     * @returns observable array of failed operation metrics matched to requested parameters.
     */
-    public getAmountOfFailedOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]> {
+    public getAmountOfFailedOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumericMetricValueType): Observable<MongooseMetric[]> {
         return this.chartDataProvider.getAmountOfFailedOperations(periodInSeconds, loadStepId, numericMetricValueType).pipe(
             map((metrics: MongooseMetric[]) => {
                 var internalMetricName: string = undefined;
                 switch (numericMetricValueType) {
-                    case (NumbericMetricValueType.LAST): {
+                    case (NumericMetricValueType.LAST): {
                         internalMetricName = InternalMetricNames.FAILED_OPERATIONS_LAST;
                         break;
                     }
-                    case (NumbericMetricValueType.MEAN): {
+                    case (NumericMetricValueType.MEAN): {
                         internalMetricName = InternalMetricNames.FAILED_OPERATIONS_MEAN;
                         break;
                     }
@@ -175,16 +175,16 @@ export class MongooseChartDao {
     * @param numericMetricValueType for bandwidth can be LAST (mean the last gathered) or MEAN (mean value).
     * @returns observable array of successful operations metrics matched to requested parameters.
     */
-    public getAmountOfSuccessfulOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]> {
+    public getAmountOfSuccessfulOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumericMetricValueType): Observable<MongooseMetric[]> {
         return this.chartDataProvider.getAmountOfSuccessfulOperations(periodInSeconds, loadStepId, numericMetricValueType).pipe(
             map((metrics: MongooseMetric[]) => {
                 var internalMetricName: string = undefined;
                 switch (numericMetricValueType) {
-                    case (NumbericMetricValueType.LAST): {
+                    case (NumericMetricValueType.LAST): {
                         internalMetricName = InternalMetricNames.SUCCESSFUL_OPERATIONS_LAST;
                         break;
                     }
-                    case (NumbericMetricValueType.MEAN): {
+                    case (NumericMetricValueType.MEAN): {
                         internalMetricName = InternalMetricNames.SUCCESSFUL_OPERATIONS_MEAN;
                         break;
                     }

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-dao.model.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-dao.model.ts
@@ -44,6 +44,27 @@ export class MongooseChartDao {
         );
     }
 
+    public getConcurrency(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]> {
+        return this.chartDataProvider.getConcurrency(periodInSeconds, loadStepId, numericMetricValueType).pipe(
+            map((metrics: MongooseMetric[]) => {
+                let internalMetricName: string = undefined;
+                switch (numericMetricValueType) {
+                    case (NumbericMetricValueType.LAST): {
+                        internalMetricName = InternalMetricNames.CONCURRENCY_LAST;
+                        break;
+                    }
+                    default: {
+                        throw new Error(`Internal metric name for metric type ${numericMetricValueType} hasn't been found for concurrency.`)
+                    }
+                }
+                metrics.forEach(metric => {
+                    metric.setName(internalMetricName);
+                });
+                return metrics;
+            })
+        )
+    }
+
     public getLatency(periodInSeconds: number, loadStepId: string, metricValueType: MetricValueType): Observable<MongooseMetric[]> {
         return this.chartDataProvider.getLatency(periodInSeconds, loadStepId, metricValueType).pipe(
             map((metrics: MongooseMetric[]) => {

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-data-provider.interface.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-data-provider.interface.ts
@@ -25,6 +25,6 @@ export interface MongooseChartDataProvider {
 
     getConcurrency(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
 
-    getElapsedTimeValue(periodInSeconds: number, loadStepId: string, numericMetricValueType): Observable<MongooseMetric[]>;
+    getElapsedTimeValue(periodInSeconds: number, loadStepId: string): Observable<MongooseMetric[]>;
 
 }

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-data-provider.interface.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-data-provider.interface.ts
@@ -25,4 +25,6 @@ export interface MongooseChartDataProvider {
 
     getConcurrency(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
 
+    getElapsedTimeValue(periodInSeconds: number, loadStepId: string, numericMetricValueType): Observable<MongooseMetric[]>;
+
 }

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-data-provider.interface.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-data-provider.interface.ts
@@ -1,7 +1,7 @@
 import { Observable } from "rxjs";
 import { MongooseMetric } from "../mongoose-metric.model";
 import { MetricValueType } from "./metric-value-type";
-import { NumbericMetricValueType } from "./numeric-metric-value-type";
+import { NumericMetricValueType } from "./numeric-metric-value-type";
 
 /**
  * Describes necessary function for provider of Mongoose metrics.
@@ -24,7 +24,7 @@ export interface MongooseChartDataProvider {
     * @param loadStepId Mongoose's load step ID for a specific run.
     * @param numericMetricValueType Type of byte rate metric (mean, last).
     */
-  getAmountOfFailedOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
+  getAmountOfFailedOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumericMetricValueType): Observable<MongooseMetric[]>;
 
   /** 
    * @returns Amount of successful operations performed by Mongoose from given period.
@@ -33,7 +33,7 @@ export interface MongooseChartDataProvider {
     * @param loadStepId Mongoose's load step ID for a specific run.
     * @param numericMetricValueType Type of byte rate metric (mean, last).
     */
-  getAmountOfSuccessfulOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
+  getAmountOfSuccessfulOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumericMetricValueType): Observable<MongooseMetric[]>;
 
   /** 
    * @returns Latency-related Mongoose's metrics.
@@ -51,7 +51,7 @@ export interface MongooseChartDataProvider {
     * @param loadStepId Mongoose's load step ID for a specific run.
     * @param numericMetricValueType Type of byte rate metric (mean, last).
     */
-  getBandWidth(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
+  getBandWidth(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumericMetricValueType): Observable<MongooseMetric[]>;
 
   /**
    * @returns Concurrency-related Mongoose's metrics.
@@ -60,7 +60,7 @@ export interface MongooseChartDataProvider {
     * @param loadStepId Mongoose's load step ID for a specific run.
     * @param numericMetricValueType Type of concurrency metric (mean, last).
     */
-  getConcurrency(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
+  getConcurrency(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumericMetricValueType): Observable<MongooseMetric[]>;
 
 
   /**

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-data-provider.interface.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-data-provider.interface.ts
@@ -3,28 +3,69 @@ import { MongooseMetric } from "../mongoose-metric.model";
 import { MetricValueType } from "./metric-value-type";
 import { NumbericMetricValueType } from "./numeric-metric-value-type";
 
+/**
+ * Describes necessary function for provider of Mongoose metrics.
+ */
 export interface MongooseChartDataProvider {
 
-    getDuration(periodInSeconds: number, loadStepId: string, metricValueType: MetricValueType): Observable<MongooseMetric[]>;
+  /** 
+   * @returns Duration-related Mongoose's metrics.
+    * @throws Error in non-existing @param metricValueType has been passed as argument.
+    * @param periodInSeconds amount of period for metrics scaping (seconds).
+    * @param loadStepId Mongoose's load step ID for a specific run.
+    * @param metricValueType Type of Latency metric (mean, max, min).
+    */
+  getDuration(periodInSeconds: number, loadStepId: string, metricValueType: MetricValueType): Observable<MongooseMetric[]>;
 
-    getAmountOfFailedOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
-    getAmountOfSuccessfulOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
+  /** 
+   * @returns Amount of failed operations performed by Mongoose from given period.
+    * @throws Error in non-existing @param numericMetricValueType has been passed as argument.
+    * @param periodInSeconds amount of period for metrics scaping (seconds).
+    * @param loadStepId Mongoose's load step ID for a specific run.
+    * @param numericMetricValueType Type of byte rate metric (mean, last).
+    */
+  getAmountOfFailedOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
 
-    // getLatencyMax(periodInSeconds: number, loadStepId: string): Observable<MongooseMetric[]>;
-    // getLatencyMin(periodInSeconds: number, loadStepId: string): Observable<MongooseMetric[]>;
+  /** 
+   * @returns Amount of successful operations performed by Mongoose from given period.
+    * @throws Error in non-existing @param numericMetricValueType has been passed as argument.
+    * @param periodInSeconds amount of period for metrics scaping (seconds).
+    * @param loadStepId Mongoose's load step ID for a specific run.
+    * @param numericMetricValueType Type of byte rate metric (mean, last).
+    */
+  getAmountOfSuccessfulOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
 
-    getLatency(periodInSeconds: number, loadStepId: string, metricValueType: MetricValueType)
-    
-      /**
-   * @throws Error in non-existing @param numericMetricValueType has been passed as argument.
-   * @param periodInSeconds amount of period for metrics scaping (seconds).
-   * @param loadStepId Mongoose's load step ID for a specific run.
-   * @param numericMetricValueType Type of byte rate metric (mean, last).
+  /** 
+   * @returns Latency-related Mongoose's metrics.
+    * @throws Error in non-existing @param metricValueType has been passed as argument.
+    * @param periodInSeconds amount of period for metrics scaping (seconds).
+    * @param loadStepId Mongoose's load step ID for a specific run.
+    * @param metricValueType Type of Latency metric (mean, max, min).
+    */
+  getLatency(periodInSeconds: number, loadStepId: string, metricValueType: MetricValueType)
+
+  /** 
+   * @returns Bandwidth-related Mongoose's metrics..
+    * @throws Error in non-existing @param numericMetricValueType has been passed as argument.
+    * @param periodInSeconds amount of period for metrics scaping (seconds).
+    * @param loadStepId Mongoose's load step ID for a specific run.
+    * @param numericMetricValueType Type of byte rate metric (mean, last).
+    */
+  getBandWidth(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
+
+  /**
+   * @returns Concurrency-related Mongoose's metrics.
+    * @throws Error in non-existing @param numericMetricValueType has been passed as argument.
+    * @param periodInSeconds amount of period for metrics scaping (seconds).
+    * @param loadStepId Mongoose's load step ID for a specific run.
+    * @param numericMetricValueType Type of concurrency metric (mean, last).
+    */
+  getConcurrency(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
+
+
+  /**
+   * @returns Mongoose's elapsed time value from given time period (@param periodInSeconds) for ...
+   * ... specified Mongoose's @param loadStepId 
    */
-    getBandWidth(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
-
-    getConcurrency(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
-
-    getElapsedTimeValue(periodInSeconds: number, loadStepId: string): Observable<MongooseMetric[]>;
-
+  getElapsedTimeValue(periodInSeconds: number, loadStepId: string): Observable<MongooseMetric[]>;
 }

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-data-provider.interface.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-data-provider.interface.ts
@@ -23,4 +23,6 @@ export interface MongooseChartDataProvider {
    */
     getBandWidth(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
 
+    getConcurrency(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]>;
+
 }

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart.interface.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart.interface.ts
@@ -2,7 +2,7 @@ import { MongooseChartOptions } from "./mongoose-chart-options";
 import { MongooseChartDao } from "../mongoose-chart-interface/mongoose-chart-dao.model";
 import { MongooseMetric } from "../mongoose-metric.model";
 import { MetricValueType } from "./metric-value-type";
-import { NumbericMetricValueType } from "./numeric-metric-value-type";
+import { NumericMetricValueType } from "./numeric-metric-value-type";
 import { ChartPoint } from "./chart-point.model";
 
 export interface MongooseChart {
@@ -16,7 +16,7 @@ export interface MongooseChart {
     //     chartData: MongooseChartDataset[];
 
     isChartDataValid: boolean;
-    shouldShiftChart: boolean; 
+    shouldShiftChart: boolean;
 
     mongooseChartDao: MongooseChartDao;
     /**
@@ -25,7 +25,7 @@ export interface MongooseChart {
      * @param metrics array of data for chart.
      * @param metricType type of metric (e.g.: min, mean, max, last, etc.)
      */
-    updateChart(recordLoadStepId: string, metrics: ChartPoint[] | MongooseMetric[], metricType?: MetricValueType | NumbericMetricValueType);
+    updateChart(recordLoadStepId: string, metrics: ChartPoint[] | MongooseMetric[], metricType?: MetricValueType | NumericMetricValueType);
 
     shouldDrawChart(): boolean;
 }

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart.interface.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart.interface.ts
@@ -4,6 +4,7 @@ import { MongooseChartDao } from "../mongoose-chart-interface/mongoose-chart-dao
 import { MongooseMetric } from "../mongoose-metric.model";
 import { MetricValueType } from "./metric-value-type";
 import { NumbericMetricValueType } from "./numeric-metric-value-type";
+import { ChartPoint } from "./chart-point.model";
 
 export interface MongooseChart {
     chartOptions: MongooseChartOptions;
@@ -19,15 +20,13 @@ export interface MongooseChart {
     shouldShiftChart: boolean; 
 
     mongooseChartDao: MongooseChartDao;
-    // TODO: Change updateChart(...) method back to normal.
     /**
      * 
      * @param recordLoadStepId load step ID of metrics provided for chart.
      * @param metrics array of data for chart.
      * @param metricType type of metric (e.g.: min, mean, max, last, etc.)
      */
-    updateChart(recordLoadStepId: string, metrics: any[], metricType?: MetricValueType | NumbericMetricValueType);
-    //     updateChart(recordLoadStepId: string, metrics: MongooseMetric[]);
+    updateChart(recordLoadStepId: string, metrics: ChartPoint[] | MongooseMetric[], metricType?: MetricValueType | NumbericMetricValueType);
 
     shouldDrawChart(): boolean;
 }

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart.interface.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart.interface.ts
@@ -8,11 +8,18 @@ export interface MongooseChart {
     chartLabels: string[];
     chartType: string;
     chartLegend: boolean;
-    chartData: MongooseChartDataset[];
+    // TODO: Change back to MongooseChartDataset[]
+    chartData: any[];
+
+    //     chartData: MongooseChartDataset[];
+
     isChartDataValid: boolean;
     shouldShiftChart: boolean; 
 
     mongooseChartDao: MongooseChartDao;
-    updateChart(recordLoadStepId: string, metrics: MongooseMetric[]);
+    // TODO: Change updateChart(...) method back to normal.
+    updateChart(recordLoadStepId: string, metrics: any[]);
+    //     updateChart(recordLoadStepId: string, metrics: MongooseMetric[]);
+
     shouldDrawChart(): boolean;
 }

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart.interface.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart.interface.ts
@@ -2,6 +2,8 @@ import { MongooseChartDataset } from "./mongoose-chart-dataset.model";
 import { MongooseChartOptions } from "./mongoose-chart-options";
 import { MongooseChartDao } from "../mongoose-chart-interface/mongoose-chart-dao.model";
 import { MongooseMetric } from "../mongoose-metric.model";
+import { MetricValueType } from "./metric-value-type";
+import { NumbericMetricValueType } from "./numeric-metric-value-type";
 
 export interface MongooseChart {
     chartOptions: MongooseChartOptions;
@@ -18,7 +20,13 @@ export interface MongooseChart {
 
     mongooseChartDao: MongooseChartDao;
     // TODO: Change updateChart(...) method back to normal.
-    updateChart(recordLoadStepId: string, metrics: any[]);
+    /**
+     * 
+     * @param recordLoadStepId load step ID of metrics provided for chart.
+     * @param metrics array of data for chart.
+     * @param metricType type of metric (e.g.: min, mean, max, last, etc.)
+     */
+    updateChart(recordLoadStepId: string, metrics: any[], metricType?: MetricValueType | NumbericMetricValueType);
     //     updateChart(recordLoadStepId: string, metrics: MongooseMetric[]);
 
     shouldDrawChart(): boolean;

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart.interface.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart.interface.ts
@@ -1,4 +1,3 @@
-import { MongooseChartDataset } from "./mongoose-chart-dataset.model";
 import { MongooseChartOptions } from "./mongoose-chart-options";
 import { MongooseChartDao } from "../mongoose-chart-interface/mongoose-chart-dao.model";
 import { MongooseMetric } from "../mongoose-metric.model";

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-test-chart-dataset.model.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-test-chart-dataset.model.ts
@@ -22,8 +22,8 @@ export class MongooseTestChartDataset {
     private readonly CHART_LINE_WIDTH_PX = 1;
     private readonly CHART_POINT_RADIUS_PX = 0;
 
-    public data: any[] = [];
-    public points: ChartPoint[] = [];
+    public data: ChartPoint[] = [];
+    // public points: ChartPoint[] = [];
     public label: string = "";
 
     public lineTension: number = this.ZERO_CURVE_LINE_TENSION;
@@ -46,13 +46,13 @@ export class MongooseTestChartDataset {
 
     // MARK: - Public 
 
-    public appendDatasetWithNewValue(newValue: string) {
-        const emptyValue = "";
-        if (newValue == emptyValue) {
-            newValue = this.getPreviousValueFromDataset(this);
-        }
-        this.data.push(newValue);
-    }
+    // public appendDatasetWithNewValue(newValue: string) {
+    //     const emptyValue = "";
+    //     if (newValue == emptyValue) {
+    //         newValue = this.getPreviousValueFromDataset(this);
+    //     }
+    //     this.data.push(newValue);
+    // }
 
     public setChartData(data: any[]) {
         this.data = data;
@@ -73,9 +73,9 @@ export class MongooseTestChartDataset {
 
     // MARK: - Private 
 
-    private getPreviousValueFromDataset(dataset: MongooseTestChartDataset): string {
-        let previosValueIndex = dataset.data.length - 1;
-        let previosValue = dataset.data[previosValueIndex];
-        return previosValue;
-    }
+    // private getPreviousValueFromDataset(dataset: MongooseTestChartDataset): string {
+    //     let previosValueIndex = dataset.data.length - 1;
+    //     let previosValue = dataset.data[previosValueIndex];
+    //     return previosValue;
+    // }
 }

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-test-chart-dataset.model.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-test-chart-dataset.model.ts
@@ -1,0 +1,81 @@
+import { ChartPoint } from "./chart-point.model";
+
+/**
+ * Chart that tests point addition with ChartPoint class. TO BE DELETED
+ */
+export class MongooseTestChartDataset {
+    // NOTE: Fields are public since they should match ng-chart2 library naming 
+    // link: https://github.com/valor-software/ng2-charts
+
+    /**
+     * @param MEAN_CHART_DEFAULT_LINE_COLOR_RGBA - yellow - default color for MEAN line on charts.
+     * @param MIN_CHART_DEFAULT_LINE_COLOR_RGBA - green - default color for MIN line on charts.
+     * @param MAX_CHART_DEFAULT_LINE_COLOR_RGBA - red - default color for MAX line on charts.
+     */
+    public static readonly MEAN_CHART_DEFAULT_LINE_COLOR_RGBA = "rgba(247, 202, 24, 1)";
+    public static readonly MIN_CHART_DEFAULT_LINE_COLOR_RGB = "rgb(255, 0, 0)";
+    public static readonly MAX_CHART_DEFAULT_LINE_COLOR_RGB = "rgb(46, 204, 113)";
+
+    private readonly ZERO_CURVE_LINE_TENSION = 0;
+    private readonly BLACK_SOLID_COLOR_RGBA = "rgba(1, 1, 1, 1)";
+    private readonly CLEAR_COLOR_RGBA = "rgba(0, 0, 0, 0)";
+    private readonly CHART_LINE_WIDTH_PX = 1;
+    private readonly CHART_POINT_RADIUS_PX = 0;
+
+    public data: any[] = [];
+    public points: ChartPoint[] = [];
+    public label: string = "";
+
+    public lineTension: number = this.ZERO_CURVE_LINE_TENSION;
+    public fill: boolean = false;
+    public backgroundColor: string = this.CLEAR_COLOR_RGBA;
+    public borderColor: string = this.BLACK_SOLID_COLOR_RGBA;
+    public borderWidth: number = this.CHART_LINE_WIDTH_PX;
+    public pointRadius: number = this.CHART_POINT_RADIUS_PX;
+    public options: Object = {
+        responsiveAnimationDuration: 0,
+        animation: {
+            duration: 100
+        }
+    }
+
+    constructor(data: any[], label: string) {
+        this.data = data;
+        this.label = label;
+    }
+
+    // MARK: - Public 
+
+    public appendDatasetWithNewValue(newValue: string) {
+        const emptyValue = "";
+        if (newValue == emptyValue) {
+            newValue = this.getPreviousValueFromDataset(this);
+        }
+        this.data.push(newValue);
+    }
+
+    public setChartData(data: any[]) {
+        this.data = data;
+    }
+
+    public addPoint(x: number, y: number) {
+        let point = new ChartPoint(x, y);
+        this.data.push(point);
+    }
+
+    /**
+     * Sets color to a specific chart. 
+     * @param colorRgba color in RGB or RGBA format. E.g.: rgba(1, 1, 1, 1)
+     */
+    public setChartColor(colorRgba: string) {
+        this.borderColor = colorRgba;
+    }
+
+    // MARK: - Private 
+
+    private getPreviousValueFromDataset(dataset: MongooseTestChartDataset): string {
+        let previosValueIndex = dataset.data.length - 1;
+        let previosValue = dataset.data[previosValueIndex];
+        return previosValue;
+    }
+}

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-test-chart-dataset.model.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-test-chart-dataset.model.ts
@@ -1,7 +1,8 @@
 import { ChartPoint } from "./chart-point.model";
 
 /**
- * Chart that tests point addition with ChartPoint class. TO BE DELETED
+ * Class that contains chart options for BasicChart component. 
+ * Options matches ng-chart2 library requirements.
  */
 export class MongooseTestChartDataset {
     // NOTE: Fields are public since they should match ng-chart2 library naming 
@@ -23,7 +24,6 @@ export class MongooseTestChartDataset {
     private readonly CHART_POINT_RADIUS_PX = 0;
 
     public data: ChartPoint[] = [];
-    // public points: ChartPoint[] = [];
     public label: string = "";
 
     public lineTension: number = this.ZERO_CURVE_LINE_TENSION;
@@ -44,16 +44,6 @@ export class MongooseTestChartDataset {
         this.label = label;
     }
 
-    // MARK: - Public 
-
-    // public appendDatasetWithNewValue(newValue: string) {
-    //     const emptyValue = "";
-    //     if (newValue == emptyValue) {
-    //         newValue = this.getPreviousValueFromDataset(this);
-    //     }
-    //     this.data.push(newValue);
-    // }
-
     public setChartData(data: any[]) {
         this.data = data;
     }
@@ -70,12 +60,4 @@ export class MongooseTestChartDataset {
     public setChartColor(colorRgba: string) {
         this.borderColor = colorRgba;
     }
-
-    // MARK: - Private 
-
-    // private getPreviousValueFromDataset(dataset: MongooseTestChartDataset): string {
-    //     let previosValueIndex = dataset.data.length - 1;
-    //     let previosValue = dataset.data[previosValueIndex];
-    //     return previosValue;
-    // }
 }

--- a/console/src/app/core/models/chart/mongoose-chart-interface/numeric-metric-value-type.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/numeric-metric-value-type.ts
@@ -1,4 +1,4 @@
-export enum NumbericMetricValueType { 
+export enum NumericMetricValueType { 
     MEAN = "numeric_mean",
     LAST = "numeric_last"
 }

--- a/console/src/app/core/models/chart/mongoose-charts-repository.ts
+++ b/console/src/app/core/models/chart/mongoose-charts-repository.ts
@@ -4,6 +4,7 @@ import { MongooseLatencyChart } from "./latency/mongoose-latency-chart.model";
 import { MongooseThroughputChart } from "./throughput/mongoose-throughput-chart.model";
 import { MongooseBandwidthChart } from "./bandwidth/mongoose-bandwidth-chart.model";
 import { MongooseChartDao } from "./mongoose-chart-interface/mongoose-chart-dao.model";
+import { MongooseConcurrencyChart } from "./concurrency/mongoose-concurrency-chart.model";
 
 /**
  * Repository of different Mongoose metrics charts. 
@@ -22,6 +23,7 @@ export class MongooseChartsRepository {
     private latencyChart: MongooseLatencyChart;
     private thoughputChart: MongooseThroughputChart;
     private bandwidthChart: MongooseBandwidthChart;
+    private concurrencyChart: MongooseConcurrencyChart;
 
     constructor(mongooseChartDao: MongooseChartDao) {
         this.mongooseChartDao = mongooseChartDao;
@@ -45,6 +47,10 @@ export class MongooseChartsRepository {
         return this.bandwidthChart;
     }
 
+    public getConcurrencyChart(): MongooseConcurrencyChart { 
+        return this.concurrencyChart;
+    }
+
     // MARK: - Private 
 
     private setUpCharts() {
@@ -52,6 +58,7 @@ export class MongooseChartsRepository {
         this.latencyChart = this.createMongooseLatencyChart();
         this.thoughputChart = this.createMongooseThroughtputChart();
         this.bandwidthChart = this.createMongooseBandwidthChart();
+        this.concurrencyChart = this.createConcurrencyChart();
     }
 
     private createMongooseDurationChart(): MongooseDurationChart {
@@ -72,6 +79,11 @@ export class MongooseChartsRepository {
     private createMongooseBandwidthChart(): MongooseBandwidthChart {
         let bandwidthChartOptions: MongooseChartOptions = this.getLogarithmicOptionsForChart();
         return new MongooseBandwidthChart(bandwidthChartOptions, this.BASIC_MONGOOSE_CHART_LABELS, this.BASIC_MONGOOSE_CHART_TYPE, this.BASIC_MONGOOSE_CHART_LEGEND_MODE, this.mongooseChartDao);
+    }
+
+    private createConcurrencyChart(): MongooseConcurrencyChart { 
+        let concurrenyChartOptions: MongooseChartOptions = new MongooseChartOptions();
+        return new MongooseConcurrencyChart(concurrenyChartOptions, this.BASIC_MONGOOSE_CHART_LABELS, this.BASIC_MONGOOSE_CHART_TYPE, this.BASIC_MONGOOSE_CHART_LEGEND_MODE, this.mongooseChartDao);
     }
 
     /**

--- a/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
+++ b/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
@@ -9,7 +9,7 @@ import { MongooseBandwidthChart } from '../../models/chart/bandwidth/mongoose-ba
 import { MongooseThroughputChart } from '../../models/chart/throughput/mongoose-throughput-chart.model';
 import { MetricValueType } from '../../models/chart/mongoose-chart-interface/metric-value-type';
 import { Observable, forkJoin } from 'rxjs';
-import { NumbericMetricValueType } from '../../models/chart/mongoose-chart-interface/numeric-metric-value-type';
+import { NumericMetricValueType } from '../../models/chart/mongoose-chart-interface/numeric-metric-value-type';
 import { ChartPoint } from '../../models/chart/mongoose-chart-interface/chart-point.model';
 import { MongooseConcurrencyChart } from '../../models/chart/concurrency/mongoose-concurrency-chart.model';
 
@@ -98,8 +98,8 @@ export class ChartsProviderService {
     })
   }
 
-  private updateConcurrencyChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType = NumbericMetricValueType.LAST) {
-    Object.values(NumbericMetricValueType).forEach(concurrencyMetricType => {
+  private updateConcurrencyChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string, numericMetricValueType: NumericMetricValueType = NumericMetricValueType.LAST) {
+    Object.values(NumericMetricValueType).forEach(concurrencyMetricType => {
       this.mongooseChartDao.getConcurrencyChartPoints(perdiodOfLatencyUpdateSecs, loadStepId, concurrencyMetricType).subscribe(
         (chartPoints: ChartPoint[]) => {
           this.concurrencyChart.updateChart(loadStepId, chartPoints, concurrencyMetricType);
@@ -111,10 +111,10 @@ export class ChartsProviderService {
 
   private updateBandwidthChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string) {
     let bandwidthMetricPool$: any[] = [];
-    let meanBandwidthMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getBandWidth(perdiodOfLatencyUpdateSecs, loadStepId, NumbericMetricValueType.MEAN);
+    let meanBandwidthMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getBandWidth(perdiodOfLatencyUpdateSecs, loadStepId, NumericMetricValueType.MEAN);
     bandwidthMetricPool$.push(meanBandwidthMetrics$);
 
-    let lastBandwidthMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getBandWidth(perdiodOfLatencyUpdateSecs, loadStepId, NumbericMetricValueType.LAST);
+    let lastBandwidthMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getBandWidth(perdiodOfLatencyUpdateSecs, loadStepId, NumericMetricValueType.LAST);
     bandwidthMetricPool$.push(lastBandwidthMetrics$);
 
     forkJoin(...bandwidthMetricPool$).subscribe((byteRateMetricCollections: [MongooseMetric[]]) => {
@@ -130,16 +130,16 @@ export class ChartsProviderService {
   private updateThoughputChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string) {
     var thoughtputMetricsPool$: Observable<MongooseMetric[]>[] = [];
 
-    let meanSuccessfulOperationMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getAmountOfSuccessfulOperations(perdiodOfLatencyUpdateSecs, loadStepId, NumbericMetricValueType.MEAN);
+    let meanSuccessfulOperationMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getAmountOfSuccessfulOperations(perdiodOfLatencyUpdateSecs, loadStepId, NumericMetricValueType.MEAN);
     thoughtputMetricsPool$.push(meanSuccessfulOperationMetrics$);
 
-    let lastSuccessfulOperationMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getAmountOfSuccessfulOperations(perdiodOfLatencyUpdateSecs, loadStepId, NumbericMetricValueType.LAST);
+    let lastSuccessfulOperationMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getAmountOfSuccessfulOperations(perdiodOfLatencyUpdateSecs, loadStepId, NumericMetricValueType.LAST);
     thoughtputMetricsPool$.push(lastSuccessfulOperationMetrics$);
 
-    let meanFailedOperationMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getAmountOfFailedOperations(perdiodOfLatencyUpdateSecs, loadStepId, NumbericMetricValueType.MEAN);
+    let meanFailedOperationMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getAmountOfFailedOperations(perdiodOfLatencyUpdateSecs, loadStepId, NumericMetricValueType.MEAN);
     thoughtputMetricsPool$.push(meanFailedOperationMetrics$);
 
-    let lastFailedOperationMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getAmountOfFailedOperations(perdiodOfLatencyUpdateSecs, loadStepId, NumbericMetricValueType.LAST);
+    let lastFailedOperationMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getAmountOfFailedOperations(perdiodOfLatencyUpdateSecs, loadStepId, NumericMetricValueType.LAST);
     thoughtputMetricsPool$.push(lastFailedOperationMetrics$);
 
     forkJoin(...thoughtputMetricsPool$).subscribe(
@@ -176,5 +176,5 @@ export class ChartsProviderService {
     }
     return chartPoints;
   }
-  
+
 }

--- a/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
+++ b/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
@@ -99,13 +99,15 @@ export class ChartsProviderService {
   }
 
   private updateConcurrencyChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType = NumbericMetricValueType.LAST) { 
-    this.mongooseChartDao.getConcurrencyChartPoints(perdiodOfLatencyUpdateSecs, loadStepId, numericMetricValueType).subscribe(
-      (chartPoints: ChartPoint[]) => { 
-        console.log(`Concurrency chart has been updated. Content: ${JSON.stringify(this.concurrencyChart.chartData[0])}`)
-        // let chartPoints: ChartPoint[] = this.getChartPointsFromMetric(metricValues);
-        this.concurrencyChart.updateChart(loadStepId, chartPoints);
-      }
-    )
+    Object.values(NumbericMetricValueType).forEach(concurrencyMetricType => { 
+      this.mongooseChartDao.getConcurrencyChartPoints(perdiodOfLatencyUpdateSecs, loadStepId, concurrencyMetricType).subscribe(
+        (chartPoints: ChartPoint[]) => { 
+          console.log(`Concurrency chart has been updated. Content: ${JSON.stringify(this.concurrencyChart.chartData[0])}`)
+          this.concurrencyChart.updateChart(loadStepId, chartPoints, concurrencyMetricType);
+        }
+      )
+    })
+    
   }
 
   private updateBandwidthChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string) {

--- a/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
+++ b/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
@@ -10,6 +10,7 @@ import { MongooseThroughputChart } from '../../models/chart/throughput/mongoose-
 import { MetricValueType } from '../../models/chart/mongoose-chart-interface/metric-value-type';
 import { Observable, forkJoin } from 'rxjs';
 import { NumbericMetricValueType } from '../../models/chart/mongoose-chart-interface/numeric-metric-value-type';
+import { ChartPoint } from '../../models/chart/mongoose-chart-interface/chart-point.model';
 
 
 @Injectable({
@@ -90,6 +91,14 @@ export class ChartsProviderService {
     })
   }
 
+  private updateConcurrencyChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType) { 
+    this.mongooseChartDao.getConcurrency(perdiodOfLatencyUpdateSecs, loadStepId, numericMetricValueType).subscribe(
+      (metricValues: MongooseMetric[]) => { 
+        let chartPoints: ChartPoint[] = this.getChartPointsFromMetric(metricValues);
+        
+      }
+    )
+  }
 
   private updateBandwidthChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string) {
     let bandwidthMetricPool$: any[] = [];
@@ -146,4 +155,16 @@ export class ChartsProviderService {
     this.throughputChart = mongooseChartRepository.getThoughputChart();
   }
 
+  private getChartPointsFromMetric(mongooseMetrics: MongooseMetric[]): ChartPoint[] { 
+    let chartPoints: ChartPoint[] = [];
+    for (let mongooseMetric of mongooseMetrics) { 
+      const x = mongooseMetric.getTimestamp();
+      const y = mongooseMetric.getValue();
+      const chartPoint = new ChartPoint(x, y);
+
+      chartPoints.push(chartPoint);
+    }
+
+    return chartPoints;
+  }
 }

--- a/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
+++ b/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
@@ -11,6 +11,7 @@ import { MetricValueType } from '../../models/chart/mongoose-chart-interface/met
 import { Observable, forkJoin } from 'rxjs';
 import { NumbericMetricValueType } from '../../models/chart/mongoose-chart-interface/numeric-metric-value-type';
 import { ChartPoint } from '../../models/chart/mongoose-chart-interface/chart-point.model';
+import { MongooseConcurrencyChart } from '../../models/chart/concurrency/mongoose-concurrency-chart.model';
 
 
 @Injectable({
@@ -25,6 +26,7 @@ export class ChartsProviderService {
   private latencyChart: MongooseLatencyChart;
   private bandwidthChart: MongooseBandwidthChart;
   private throughputChart: MongooseThroughputChart;
+  private concurrencyChart: MongooseConcurrencyChart;
 
   constructor(prometheusApiService: PrometheusApiService) {
     // NOTE: Prometheus API service is data provider for Mongoose Charts.
@@ -49,6 +51,10 @@ export class ChartsProviderService {
 
   public getLatencyChart(): MongooseLatencyChart {
     return this.latencyChart;
+  }
+
+  public getConcurrencyChart(): MongooseConcurrencyChart { 
+    return this.concurrencyChart; 
   }
 
   public updateCharts(perdiodOfLatencyUpdateSeconds: number, loadStepId: string) {
@@ -158,8 +164,8 @@ export class ChartsProviderService {
   private getChartPointsFromMetric(mongooseMetrics: MongooseMetric[]): ChartPoint[] { 
     let chartPoints: ChartPoint[] = [];
     for (let mongooseMetric of mongooseMetrics) { 
-      const x = mongooseMetric.getTimestamp();
-      const y = mongooseMetric.getValue();
+      const x: number = mongooseMetric.getTimestamp();
+      const y: number = new Number(mongooseMetric.getValue()) as number;
       const chartPoint = new ChartPoint(x, y);
 
       chartPoints.push(chartPoint);

--- a/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
+++ b/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
@@ -62,6 +62,7 @@ export class ChartsProviderService {
     this.updateLatencyChart(perdiodOfLatencyUpdateSeconds, loadStepId);
     this.updateBandwidthChart(perdiodOfLatencyUpdateSeconds, loadStepId);
     this.updateThoughputChart(perdiodOfLatencyUpdateSeconds, loadStepId);
+    this.updateConcurrencyChart(perdiodOfLatencyUpdateSeconds, loadStepId);
   }
 
   public drawStatisCharts(secondsSinceCurrentDate: number, loadStepId: string) {
@@ -97,11 +98,11 @@ export class ChartsProviderService {
     })
   }
 
-  private updateConcurrencyChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType) { 
+  private updateConcurrencyChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType = NumbericMetricValueType.LAST) { 
     this.mongooseChartDao.getConcurrency(perdiodOfLatencyUpdateSecs, loadStepId, numericMetricValueType).subscribe(
       (metricValues: MongooseMetric[]) => { 
         let chartPoints: ChartPoint[] = this.getChartPointsFromMetric(metricValues);
-        
+        this.concurrencyChart.updateChart(loadStepId, chartPoints);
       }
     )
   }
@@ -159,6 +160,7 @@ export class ChartsProviderService {
     this.latencyChart = mongooseChartRepository.getLatencyChart();
     this.bandwidthChart = mongooseChartRepository.getBandwidthChart();
     this.throughputChart = mongooseChartRepository.getThoughputChart();
+    this.concurrencyChart = mongooseChartRepository.getConcurrencyChart();
   }
 
   private getChartPointsFromMetric(mongooseMetrics: MongooseMetric[]): ChartPoint[] { 

--- a/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
+++ b/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
@@ -99,9 +99,9 @@ export class ChartsProviderService {
   }
 
   private updateConcurrencyChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType = NumbericMetricValueType.LAST) { 
-    this.mongooseChartDao.getConcurrency(perdiodOfLatencyUpdateSecs, loadStepId, numericMetricValueType).subscribe(
-      (metricValues: MongooseMetric[]) => { 
-        let chartPoints: ChartPoint[] = this.getChartPointsFromMetric(metricValues);
+    this.mongooseChartDao.getConcurrencyChartPoints(perdiodOfLatencyUpdateSecs, loadStepId, numericMetricValueType).subscribe(
+      (chartPoints: ChartPoint[]) => { 
+        // let chartPoints: ChartPoint[] = this.getChartPointsFromMetric(metricValues);
         this.concurrencyChart.updateChart(loadStepId, chartPoints);
       }
     )

--- a/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
+++ b/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
@@ -53,8 +53,8 @@ export class ChartsProviderService {
     return this.latencyChart;
   }
 
-  public getConcurrencyChart(): MongooseConcurrencyChart { 
-    return this.concurrencyChart; 
+  public getConcurrencyChart(): MongooseConcurrencyChart {
+    return this.concurrencyChart;
   }
 
   public updateCharts(perdiodOfLatencyUpdateSeconds: number, loadStepId: string) {
@@ -73,24 +73,24 @@ export class ChartsProviderService {
   // MARK: - Private
 
   private updateLatencyChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string) {
-    Object.values(MetricValueType).forEach(metricValueType => { 
+    Object.values(MetricValueType).forEach(metricValueType => {
       this.mongooseChartDao.getLatency(perdiodOfLatencyUpdateSecs, loadStepId, MetricValueType.MAX).subscribe((maxLatencyResult: MongooseMetric[]) => {
         this.mongooseChartDao.getLatency(perdiodOfLatencyUpdateSecs, loadStepId, MetricValueType.MIN).subscribe((minLatencyResult: MongooseMetric[]) => {
           this.mongooseChartDao.getLatency(perdiodOfLatencyUpdateSecs, loadStepId, MetricValueType.MEAN).subscribe((meanLatencyResult: MongooseMetric[]) => {
-          // NOTE: Concadentation of the arrays due tothe specific logic of updating (based on the internal names)
-          let concatenatedMetrics = maxLatencyResult.concat(minLatencyResult).concat(meanLatencyResult);
-          this.latencyChart.updateChart(loadStepId, concatenatedMetrics);
+            // NOTE: Concadentation of the arrays due tothe specific logic of updating (based on the internal names)
+            let concatenatedMetrics = maxLatencyResult.concat(minLatencyResult).concat(meanLatencyResult);
+            this.latencyChart.updateChart(loadStepId, concatenatedMetrics);
           })
-          
+
         });
       });
     })
-   
+
   }
 
   private updateDurationChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string, metricValueType: MetricValueType = MetricValueType.MEAN) {
-   // NOTE: Metric value type could be min ,max or mean 
-    Object.values(MetricValueType).forEach(metricValueType => { 
+    // NOTE: Metric value type could be min ,max or mean 
+    Object.values(MetricValueType).forEach(metricValueType => {
       this.mongooseChartDao.getDuration(perdiodOfLatencyUpdateSecs, loadStepId, metricValueType).subscribe(
         ((durationMetrics: MongooseMetric[]) => {
           this.durationChart.updateChart(loadStepId, durationMetrics);
@@ -98,30 +98,29 @@ export class ChartsProviderService {
     })
   }
 
-  private updateConcurrencyChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType = NumbericMetricValueType.LAST) { 
-    Object.values(NumbericMetricValueType).forEach(concurrencyMetricType => { 
+  private updateConcurrencyChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType = NumbericMetricValueType.LAST) {
+    Object.values(NumbericMetricValueType).forEach(concurrencyMetricType => {
       this.mongooseChartDao.getConcurrencyChartPoints(perdiodOfLatencyUpdateSecs, loadStepId, concurrencyMetricType).subscribe(
-        (chartPoints: ChartPoint[]) => { 
-          console.log(`Concurrency chart has been updated. Content: ${JSON.stringify(this.concurrencyChart.chartData[0])}`)
+        (chartPoints: ChartPoint[]) => {
           this.concurrencyChart.updateChart(loadStepId, chartPoints, concurrencyMetricType);
         }
       )
-    })
-    
+    });
+
   }
 
   private updateBandwidthChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string) {
     let bandwidthMetricPool$: any[] = [];
-    let meanBandwidthMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getBandWidth(perdiodOfLatencyUpdateSecs, loadStepId, NumbericMetricValueType.MEAN); 
+    let meanBandwidthMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getBandWidth(perdiodOfLatencyUpdateSecs, loadStepId, NumbericMetricValueType.MEAN);
     bandwidthMetricPool$.push(meanBandwidthMetrics$);
 
-    let lastBandwidthMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getBandWidth(perdiodOfLatencyUpdateSecs, loadStepId, NumbericMetricValueType.LAST); 
+    let lastBandwidthMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getBandWidth(perdiodOfLatencyUpdateSecs, loadStepId, NumbericMetricValueType.LAST);
     bandwidthMetricPool$.push(lastBandwidthMetrics$);
 
     forkJoin(...bandwidthMetricPool$).subscribe((byteRateMetricCollections: [MongooseMetric[]]) => {
       // NOTE: Concatenating fetched metrics because of the updateChart() function specification.
       let fetchedByteRateMetrics: MongooseMetric[] = [];
-      for (var byteRateCollection of byteRateMetricCollections) { 
+      for (var byteRateCollection of byteRateMetricCollections) {
         fetchedByteRateMetrics = fetchedByteRateMetrics.concat(byteRateCollection);
       }
       this.bandwidthChart.updateChart(loadStepId, fetchedByteRateMetrics);
@@ -130,7 +129,7 @@ export class ChartsProviderService {
 
   private updateThoughputChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string) {
     var thoughtputMetricsPool$: Observable<MongooseMetric[]>[] = [];
-   
+
     let meanSuccessfulOperationMetrics$: Observable<MongooseMetric[]> = this.mongooseChartDao.getAmountOfSuccessfulOperations(perdiodOfLatencyUpdateSecs, loadStepId, NumbericMetricValueType.MEAN);
     thoughtputMetricsPool$.push(meanSuccessfulOperationMetrics$);
 
@@ -147,7 +146,7 @@ export class ChartsProviderService {
       (fetchedMetrics: [MongooseMetric[]]) => {
         let concatenatedMetric: MongooseMetric[] = [];
 
-        for (let metricCollection of fetchedMetrics) { 
+        for (let metricCollection of fetchedMetrics) {
           concatenatedMetric = concatenatedMetric.concat(metricCollection);
         }
 
@@ -166,16 +165,16 @@ export class ChartsProviderService {
     this.concurrencyChart = mongooseChartRepository.getConcurrencyChart();
   }
 
-  private getChartPointsFromMetric(mongooseMetrics: MongooseMetric[]): ChartPoint[] { 
+  private getChartPointsFromMetric(mongooseMetrics: MongooseMetric[]): ChartPoint[] {
     let chartPoints: ChartPoint[] = [];
-    for (let mongooseMetric of mongooseMetrics) { 
+    for (let mongooseMetric of mongooseMetrics) {
       const x: number = mongooseMetric.getTimestamp();
       const y: number = new Number(mongooseMetric.getValue()) as number;
       const chartPoint = new ChartPoint(x, y);
 
       chartPoints.push(chartPoint);
     }
-
     return chartPoints;
   }
+  
 }

--- a/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
+++ b/console/src/app/core/services/charts-provider-service/charts-provider.service.ts
@@ -101,6 +101,7 @@ export class ChartsProviderService {
   private updateConcurrencyChart(perdiodOfLatencyUpdateSecs: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType = NumbericMetricValueType.LAST) { 
     this.mongooseChartDao.getConcurrencyChartPoints(perdiodOfLatencyUpdateSecs, loadStepId, numericMetricValueType).subscribe(
       (chartPoints: ChartPoint[]) => { 
+        console.log(`Concurrency chart has been updated. Content: ${JSON.stringify(this.concurrencyChart.chartData[0])}`)
         // let chartPoints: ChartPoint[] = this.getChartPointsFromMetric(metricValues);
         this.concurrencyChart.updateChart(loadStepId, chartPoints);
       }

--- a/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
+++ b/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
@@ -9,7 +9,7 @@ import { PrometheusResponseParser } from './prometheus-response.parser';
 import { HttpUtils } from 'src/app/common/HttpUtils';
 import { LocalStorageService } from '../local-storage-service/local-storage.service';
 import { MetricValueType } from '../../models/chart/mongoose-chart-interface/metric-value-type';
-import { NumbericMetricValueType } from '../../models/chart/mongoose-chart-interface/numeric-metric-value-type';
+import { NumericMetricValueType } from '../../models/chart/mongoose-chart-interface/numeric-metric-value-type';
 
 
 @Injectable({
@@ -85,7 +85,7 @@ export class PrometheusApiService implements MongooseChartDataProvider {
   getElapsedTimeValue(periodInSeconds: number, loadStepId: string): Observable<MongooseMetric[]> {
     let metricName = this.ELAPSED_TIME_VALUE_METRIC_NAME;
     return this.runQuery(`${metricName}{load_step_id="${loadStepId}"}[${periodInSeconds}s]`).pipe(
-      map (rawConcurrencyResponse => {
+      map(rawConcurrencyResponse => {
         return this.prometheusResponseParser.getMongooseMetricsArray(rawConcurrencyResponse);
       })
     )
@@ -98,24 +98,24 @@ export class PrometheusApiService implements MongooseChartDataProvider {
     this.currentPrometheusAddress = prometheusHostIpAddress;
   }
 
-  getConcurrency(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]> {
+  getConcurrency(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumericMetricValueType): Observable<MongooseMetric[]> {
     let metricName: string = "";
-    switch (numericMetricValueType) { 
-      case (NumbericMetricValueType.LAST): { 
-        metricName = this.LAST_CONCURRENCY_METRIC_NAME; 
+    switch (numericMetricValueType) {
+      case (NumericMetricValueType.LAST): {
+        metricName = this.LAST_CONCURRENCY_METRIC_NAME;
         break;
       }
-      case (NumbericMetricValueType.MEAN): { 
+      case (NumericMetricValueType.MEAN): {
         metricName = this.MEAN_CONCURRENCY_METRIC_NAME;
         break;
       }
-      default: { 
+      default: {
         throw new Error(`Metric value type ${numericMetricValueType} hasn't been found for concurrency.`);
       }
     }
 
     return this.runQuery(`${metricName}{load_step_id="${loadStepId}"}[${periodInSeconds}s]`).pipe(
-      map (rawConcurrencyResponse => {
+      map(rawConcurrencyResponse => {
         return this.prometheusResponseParser.getMongooseMetricsArray(rawConcurrencyResponse);
       })
     )
@@ -149,14 +149,14 @@ export class PrometheusApiService implements MongooseChartDataProvider {
     );
   }
 
-  public getAmountOfFailedOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]> {
+  public getAmountOfFailedOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumericMetricValueType): Observable<MongooseMetric[]> {
     let metricName: string = "";
     switch (numericMetricValueType) {
-      case (NumbericMetricValueType.MEAN): {
+      case (NumericMetricValueType.MEAN): {
         metricName = this.FAILED_OPERATIONS_RATE_MEAN_METRIC_NAME;
         break;
       }
-      case (NumbericMetricValueType.LAST): {
+      case (NumericMetricValueType.LAST): {
         metricName = this.FAILED_OPERATIONS_RATE_LAST_METRIC_NAME;
         break;
       }
@@ -172,14 +172,14 @@ export class PrometheusApiService implements MongooseChartDataProvider {
     )
   }
 
-  public getAmountOfSuccessfulOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]> {
+  public getAmountOfSuccessfulOperations(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumericMetricValueType): Observable<MongooseMetric[]> {
     let metricName: string = "";
     switch (numericMetricValueType) {
-      case (NumbericMetricValueType.MEAN): {
+      case (NumericMetricValueType.MEAN): {
         metricName = this.SUCCESS_OPERATIONS_RATE_MEAN_METRIC_NAME;
         break;
       }
-      case (NumbericMetricValueType.LAST): {
+      case (NumericMetricValueType.LAST): {
         metricName = this.SUCCESS_OPERATIONS_RATE_LAST_METRIC_NAME;
         break;
       }
@@ -221,14 +221,14 @@ export class PrometheusApiService implements MongooseChartDataProvider {
     )
   }
 
-  public getBandWidth(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumbericMetricValueType): Observable<MongooseMetric[]> {
+  public getBandWidth(periodInSeconds: number, loadStepId: string, numericMetricValueType: NumericMetricValueType): Observable<MongooseMetric[]> {
     let metricName = this.BYTE_RATE_MEAN_METRIC_NAME;
     switch (numericMetricValueType) {
-      case (NumbericMetricValueType.MEAN): {
+      case (NumericMetricValueType.MEAN): {
         metricName = this.BYTE_RATE_MEAN_METRIC_NAME;
         break;
       }
-      case (NumbericMetricValueType.LAST): {
+      case (NumericMetricValueType.LAST): {
         metricName = this.BYTE_RATE_LAST_METRIC_NAME;
         break;
       }

--- a/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
+++ b/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
@@ -20,6 +20,8 @@ import { NumbericMetricValueType } from '../../models/chart/mongoose-chart-inter
 export class PrometheusApiService implements MongooseChartDataProvider {
 
   private readonly LAST_CONCURRENCY_METRIC_NAME = "mongoose_concurrency_last";
+  private readonly MEAN_CONCURRENCY_METRIC_NAME = "mongoose_concurrency_mean";
+
 
   private readonly MAX_LATENCY_METRIC_NAME = "mongoose_latency_max";
   private readonly MIN_LATENCY_METRIC_NAME = "mongoose_latency_min";
@@ -102,6 +104,10 @@ export class PrometheusApiService implements MongooseChartDataProvider {
     switch (numericMetricValueType) { 
       case (NumbericMetricValueType.LAST): { 
         metricName = this.LAST_CONCURRENCY_METRIC_NAME; 
+        break;
+      }
+      case (NumbericMetricValueType.MEAN): { 
+        metricName = this.MEAN_CONCURRENCY_METRIC_NAME;
         break;
       }
       default: { 

--- a/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
+++ b/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
@@ -38,6 +38,8 @@ export class PrometheusApiService implements MongooseChartDataProvider {
   private readonly BYTE_RATE_MEAN_METRIC_NAME = "mongoose_byte_rate_mean";
   private readonly BYTE_RATE_LAST_METRIC_NAME = "mongoose_byte_rate_last";
 
+  private readonly ELAPSED_TIME_VALUE_METRIC_NAME = "mongoose_elapsed_time_value";
+
   // NOTE: Symbols used for queryting Prometheus for value of metric with specific labels. They ...
   // ... are listed within the labels list. 
   readonly METRIC_LABELS_LIST_START_SYMBOL = "{";
@@ -76,6 +78,15 @@ export class PrometheusApiService implements MongooseChartDataProvider {
           return of(false);
         }
       )
+    )
+  }
+
+  getElapsedTimeValue(periodInSeconds: number, loadStepId: string, numericMetricValueType: any): Observable<MongooseMetric[]> {
+    let metricName = this.ELAPSED_TIME_VALUE_METRIC_NAME;
+    return this.runQuery(`${metricName}{load_step_id="${loadStepId}"}[${periodInSeconds}s]`).pipe(
+      map (rawConcurrencyResponse => {
+        return this.prometheusResponseParser.getMongooseMetricsArray(rawConcurrencyResponse);
+      })
     )
   }
 

--- a/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
+++ b/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
@@ -81,7 +81,7 @@ export class PrometheusApiService implements MongooseChartDataProvider {
     )
   }
 
-  getElapsedTimeValue(periodInSeconds: number, loadStepId: string, numericMetricValueType: any): Observable<MongooseMetric[]> {
+  getElapsedTimeValue(periodInSeconds: number, loadStepId: string): Observable<MongooseMetric[]> {
     let metricName = this.ELAPSED_TIME_VALUE_METRIC_NAME;
     return this.runQuery(`${metricName}{load_step_id="${loadStepId}"}[${periodInSeconds}s]`).pipe(
       map (rawConcurrencyResponse => {

--- a/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
+++ b/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
@@ -22,7 +22,6 @@ export class PrometheusApiService implements MongooseChartDataProvider {
   private readonly LAST_CONCURRENCY_METRIC_NAME = "mongoose_concurrency_last";
   private readonly MEAN_CONCURRENCY_METRIC_NAME = "mongoose_concurrency_mean";
 
-
   private readonly MAX_LATENCY_METRIC_NAME = "mongoose_latency_max";
   private readonly MIN_LATENCY_METRIC_NAME = "mongoose_latency_min";
   private readonly MEAN_LATENCY_METRIC_NAME = "mongoose_latency_mean";

--- a/console/src/app/modules/app-module/components/run-statistics/run-statistics-charts/run-statistics-charts.component.ts
+++ b/console/src/app/modules/app-module/components/run-statistics/run-statistics-charts/run-statistics-charts.component.ts
@@ -122,6 +122,7 @@ export class RunStatisticsChartsComponent implements OnInit {
     chartsList.set("Bandwidth", this.chartsProviderService.getBandwidthChart());
     chartsList.set("Throughtput", this.chartsProviderService.getThoughputChart());
     chartsList.set("Latency", this.chartsProviderService.getLatencyChart());
+    chartsList.set("Concurrency", this.chartsProviderService.getConcurrencyChart());
 
     // NOTE: Chart is being shifted after specific amount of values if Mongoose run is ...
     // ... still in process.


### PR DESCRIPTION
Add "concurrency" chart into charts section at run statistics screen. The chart should be based on the following metrics: 
- mongoose_ concurrency_mean; 
- mongoose_ concurrency_last; 
Both last and mean metrics should be displayed.

Related JIRA's task: https://mongoose-issues.atlassian.net/projects/GUI/issues/GUI-144?filter=allopenissues&orderby=priority%20DESC
