### PR TITLE
[GUI-149] Remove negative values from Y axes.

### DIFF
--- a/console/src/app/core/models/chart/bandwidth/mongoose-bandwidth-chart.model.ts
+++ b/console/src/app/core/models/chart/bandwidth/mongoose-bandwidth-chart.model.ts
@@ -10,7 +10,7 @@ import { NumericMetricValueType } from "../mongoose-chart-interface/numeric-metr
 export class MongooseBandwidthChart implements MongooseChart {
 
     private readonly Y_AXIS_CHART_TITLE: string = "MBs per second";
-    private readonly X_AXIS_CHART_TITLE: string = "Seconds";
+    private readonly X_AXIS_CHART_TITLE: string = MongooseChartOptions.ELAPSED_TIME_AXES_DEFAULT_TAG;
 
     private readonly MEAN_BANDWIDTH_DATASET_INDEX = 0;
     private readonly LAST_BANDWIDTH_DATASET_INDEX = 1;

--- a/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
+++ b/console/src/app/core/models/chart/concurrency/mongoose-concurrency-chart.model.ts
@@ -17,7 +17,7 @@ export class MongooseConcurrencyChart implements MongooseChart {
      */
 
     private readonly Y_AXIS_CHART_TITLE: string = "Concurrency value";
-    private readonly X_AXIS_CHART_TITLE: string = "Seconds";
+    private readonly X_AXIS_CHART_TITLE: string = MongooseChartOptions.ELAPSED_TIME_AXES_DEFAULT_TAG;
 
     private readonly MEAN_CONCURRENT_METRICS_DATASET_INDEX = 0;
     private readonly LAST_CONCURRENT_METRICS_DATASET_INDEX = 1;

--- a/console/src/app/core/models/chart/duration/mongoose-duration-chart.model.ts
+++ b/console/src/app/core/models/chart/duration/mongoose-duration-chart.model.ts
@@ -10,7 +10,7 @@ import { MetricValueType } from "../mongoose-chart-interface/metric-value-type";
 export class MongooseDurationChart implements MongooseChart {
 
     private readonly Y_AXIS_CHART_TITLE: string = "Milliseconds";
-    private readonly X_AXIS_CHART_TITLE: string = "Seconds";
+    private readonly X_AXIS_CHART_TITLE: string = MongooseChartOptions.ELAPSED_TIME_AXES_DEFAULT_TAG;
 
     private readonly MIN_DURATION_DATASET_INDEX = 0;
     private readonly MAX_DURATION_DATASET_INDEX = 1;

--- a/console/src/app/core/models/chart/latency/mongoose-latency-chart.model.ts
+++ b/console/src/app/core/models/chart/latency/mongoose-latency-chart.model.ts
@@ -11,7 +11,7 @@ import { MongooseDurationChart } from "../duration/mongoose-duration-chart.model
 export class MongooseLatencyChart implements MongooseChart {
 
     private readonly Y_AXIS_CHART_TITLE: string = "Milliseconds";
-    private readonly X_AXIS_CHART_TITLE: string = "Seconds";
+    private readonly X_AXIS_CHART_TITLE: string = MongooseChartOptions.ELAPSED_TIME_AXES_DEFAULT_TAG;
 
     private readonly MIN_LATENCY_DATASET_INDEX = 0;
     private readonly MAX_LATENCY_DATASET_INDEX = 1;

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-options.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-options.ts
@@ -11,7 +11,7 @@ export class MongooseChartOptions {
     public static readonly MEAN_VALUE_DEFAULT_COLOR_RGB = MongooseChartOptions.DARK_ORANGE_COLOR_RGB;
     public static readonly MAX_VALUE_DEFAULT_COLOR_RGB = MongooseChartOptions.RED_COLOR_RGB;
     public static readonly MIN_VALUE_DEFAUT_COLOR_RGB: string = MongooseChartOptions.GREEN_COLOR_RGB;
-
+    public static readonly ELAPSED_TIME_AXES_DEFAULT_TAG: string = "Elapsed time since load step start, seconds"
     public static readonly SHOULD_ALLOW_NEGATIVE_VALUES_FOR_AXES: boolean = false; 
 
     public static readonly LAST_VALUE_DEFAULT_COLOR_RGB: string = MongooseChartOptions.MEDIUM_BLUE_COLOR_RGB;

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-options.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-options.ts
@@ -12,6 +12,8 @@ export class MongooseChartOptions {
     public static readonly MAX_VALUE_DEFAULT_COLOR_RGB = MongooseChartOptions.RED_COLOR_RGB;
     public static readonly MIN_VALUE_DEFAUT_COLOR_RGB: string = MongooseChartOptions.GREEN_COLOR_RGB;
 
+    public static readonly SHOULD_ALLOW_NEGATIVE_VALUES_FOR_Y_AXES: boolean = false; 
+
     public static readonly LAST_VALUE_DEFAULT_COLOR_RGB: string = MongooseChartOptions.MEDIUM_BLUE_COLOR_RGB;
     /**
      * @param CHART_DEFAULT_TYPE specifies default type of chart drawn via ChartJS library. "Linear" is a default value.
@@ -35,6 +37,9 @@ export class MongooseChartOptions {
                 display: true,
                 labelString: MongooseChartOptions.DEAULT_Y_AXIS_TITLE
             },
+            ticks: {
+                beginAtZero: !MongooseChartOptions.SHOULD_ALLOW_NEGATIVE_VALUES_FOR_Y_AXES
+            }
         }],
         xAxes: [{
             scaleLabel: {

--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-options.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-options.ts
@@ -12,7 +12,7 @@ export class MongooseChartOptions {
     public static readonly MAX_VALUE_DEFAULT_COLOR_RGB = MongooseChartOptions.RED_COLOR_RGB;
     public static readonly MIN_VALUE_DEFAUT_COLOR_RGB: string = MongooseChartOptions.GREEN_COLOR_RGB;
 
-    public static readonly SHOULD_ALLOW_NEGATIVE_VALUES_FOR_Y_AXES: boolean = false; 
+    public static readonly SHOULD_ALLOW_NEGATIVE_VALUES_FOR_AXES: boolean = false; 
 
     public static readonly LAST_VALUE_DEFAULT_COLOR_RGB: string = MongooseChartOptions.MEDIUM_BLUE_COLOR_RGB;
     /**
@@ -38,7 +38,7 @@ export class MongooseChartOptions {
                 labelString: MongooseChartOptions.DEAULT_Y_AXIS_TITLE
             },
             ticks: {
-                beginAtZero: !MongooseChartOptions.SHOULD_ALLOW_NEGATIVE_VALUES_FOR_Y_AXES
+                beginAtZero: !MongooseChartOptions.SHOULD_ALLOW_NEGATIVE_VALUES_FOR_AXES
             }
         }],
         xAxes: [{
@@ -46,6 +46,9 @@ export class MongooseChartOptions {
                 display: true,
                 labelString: MongooseChartOptions.DEAULT_Y_AXIS_TITLE
             },
+            ticks: {
+                beginAtZero: !MongooseChartOptions.SHOULD_ALLOW_NEGATIVE_VALUES_FOR_AXES
+            }
         }]
     }
 

--- a/console/src/app/core/models/chart/throughput/mongoose-throughput-chart.model.ts
+++ b/console/src/app/core/models/chart/throughput/mongoose-throughput-chart.model.ts
@@ -11,7 +11,7 @@ import { ChartPoint } from "../mongoose-chart-interface/chart-point.model";
 export class MongooseThroughputChart implements MongooseChart {
 
     private readonly Y_AXIS_CHART_TITLE: string = "Operations per second";
-    private readonly X_AXIS_CHART_TITLE: string = "Seconds";
+    private readonly X_AXIS_CHART_TITLE: string = MongooseChartOptions.ELAPSED_TIME_AXES_DEFAULT_TAG;
 
     private readonly SUCCESSFUL_OPERATIONS_MEAN_DATASET_INDEX = 0;
     private readonly SUCCESSFUL_OPERATIONS_LAST_DATASET_INDEX = 1;


### PR DESCRIPTION
Charts shouldn't contain negative values for Y axes since it's not possible to have a negative duration, negative latency, etc.

Related JIRA's task: https://mongoose-issues.atlassian.net/projects/GUI/issues/GUI-149