### PR TITLE
[GUI-135] Add progress spinner until Mongoose run gets added.

### DIFF
--- a/console/src/app/core/services/mongoose-data-shared-service/mongoose-data-shared-service.service.ts
+++ b/console/src/app/core/services/mongoose-data-shared-service/mongoose-data-shared-service.service.ts
@@ -13,6 +13,8 @@ import { map } from 'rxjs/operators';
 })
 export class MongooseDataSharedServiceService {
 
+  public shouldWaintForNewRun: boolean = false; 
+
   private mongooseNodesRepository: MongooseRunNodesRepository = new MongooseRunNodesRepository();
 
   constructor(private localStorageService: LocalStorageService) {

--- a/console/src/app/modules/app-module/components/runs-table/runs-table.component.html
+++ b/console/src/app/modules/app-module/components/runs-table/runs-table.component.html
@@ -14,11 +14,17 @@
   <!-- MARK: - Column content -->
 
   <tbody>
+    <tr>
+      <th *ngIf="this.shouldAppearLoadSpinner()">
+          <div class="spinner-border" role="status">
+              <span class="sr-only">Loading...</span>
+            </div>
+      </th>
+    </tr>
     <tr *ngFor="let runRecord of mongooseRunRecords">
       <th scope="row">
         <app-mongoose-run-status-icon [runStatus]="runRecord.getStatus()" (click)="onRunStatusIconClicked(runRecord)">
           {{ runRecord.getStatus() }}
-
         </app-mongoose-run-status-icon>
       </th>
 

--- a/console/src/app/modules/app-module/components/runs-table/runs-table.component.html
+++ b/console/src/app/modules/app-module/components/runs-table/runs-table.component.html
@@ -13,14 +13,20 @@
 
   <!-- MARK: - Column content -->
 
+ 
   <tbody>
-    <tr>
-      <th *ngIf="this.shouldAppearLoadSpinner()">
-          <div class="spinner-border" role="status">
-              <span class="sr-only">Loading...</span>
-            </div>
-      </th>
-    </tr>
+   <tr *ngIf="this.shouldAppearLoadSpinner()">
+     <!-- NOTE: Colspan should be equal to amount of overlaying columns. -->
+      <td align="center" colspan="5">
+          <!-- NOTE: Loading spinner. It appears if a Mongoose run has been launched, but its metrics ...
+          ... weren't exported to Prometheus yet. -->
+          <button class="btn btn-light" style="width: calc(50%);">
+              <span class="spinner-border spinner-border-sm"></span>
+              Loading Mongoose run..
+            </button>
+        </td>
+   </tr>
+    
     <tr *ngFor="let runRecord of mongooseRunRecords">
       <th scope="row">
         <app-mongoose-run-status-icon [runStatus]="runRecord.getStatus()" (click)="onRunStatusIconClicked(runRecord)">

--- a/console/src/app/modules/app-module/components/runs-table/runs-table.component.ts
+++ b/console/src/app/modules/app-module/components/runs-table/runs-table.component.ts
@@ -6,6 +6,7 @@ import { MonitoringApiService } from '../../../../core/services/monitoring-api/m
 import { timer, Observable, Subscription } from 'rxjs';
 
 import { MongooseRunStatus } from '../../../../core/models/mongoose-run-status';
+import { MongooseDataSharedServiceService } from 'src/app/core/services/mongoose-data-shared-service/mongoose-data-shared-service.service';
 
 @Component({
   selector: 'app-runs-table',
@@ -32,7 +33,8 @@ export class RunsTableComponent implements OnInit {
   private statusUpdateSubscription: Subscription = new Subscription();
 
   constructor(private router: Router,
-    private monitoringApiService: MonitoringApiService) { }
+    private monitoringApiService: MonitoringApiService,
+    private mongooseDataSharedServiceService: MongooseDataSharedServiceService) { }
 
   // MARK: - Lifecycle 
 
@@ -53,6 +55,10 @@ export class RunsTableComponent implements OnInit {
   }
 
   // MARK: - Public 
+
+  public shouldAppearLoadSpinner(): boolean {
+    return this.mongooseDataSharedServiceService.shouldWaintForNewRun;
+  }
 
   public getDisplayingTimeForRecord(record: MongooseRunRecord): string { 
     let unixEpochStartTime = record.getStartTime(); 

--- a/console/src/app/modules/app-module/components/runs-table/runs-table.component.ts
+++ b/console/src/app/modules/app-module/components/runs-table/runs-table.component.ts
@@ -40,6 +40,9 @@ export class RunsTableComponent implements OnInit {
 
   ngOnInit() {
 
+    if (this.mongooseDataSharedServiceService.shouldWaintForNewRun) { 
+      console.log("should wait")
+    }
     this.runRecordsSubscription = this.mongooseRunRecords$.subscribe(
       updatedRecords => {
         this.handleRecordsUpdate(updatedRecords);

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/mongoose-set-up.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/mongoose-set-up.component.ts
@@ -7,6 +7,7 @@ import { Subscription } from 'rxjs';
 import { Constants } from '../../../../common/constants';
 import { MongooseSetUpService } from '../../../../core/services/mongoose-set-up-service/mongoose-set-up.service';
 import { NodesComponent } from './set-up-steps/nodes/nodes.component';
+import { MongooseDataSharedServiceService } from 'src/app/core/services/mongoose-data-shared-service/mongoose-data-shared-service.service';
 
 @Component({
   selector: 'app-mongoose-set-up',
@@ -37,7 +38,8 @@ export class MongooseSetUpComponent implements OnInit {
 
   constructor(
     private router: Router,
-    private mongooseSetUpService: MongooseSetUpService) {
+    private mongooseSetUpService: MongooseSetUpService,
+    private mongooseDataSharedServiceService: MongooseDataSharedServiceService) {
     this.initSetUpTabs();
     let defaultTabNumber = 0;
     this.openUpTab(defaultTabNumber);
@@ -95,7 +97,7 @@ export class MongooseSetUpComponent implements OnInit {
         // ... it won't be implimented, map them here. If you want to get ...
         // ... load step id, you can do it via mongoose set up service. 
         console.log("Launched Mongoose run with run ID: ", mongooseRunId);
-
+        this.mongooseDataSharedServiceService.shouldWaintForNewRun = true; 
         // NOTE: If run ID has been returned from the server, Mongoose run has started
         let hasMongooseSuccessfullyStarted = (mongooseRunId != undefined);
         if (!hasMongooseSuccessfullyStarted) {

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/mongoose-set-up.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/mongoose-set-up.component.ts
@@ -97,7 +97,10 @@ export class MongooseSetUpComponent implements OnInit {
         // ... it won't be implimented, map them here. If you want to get ...
         // ... load step id, you can do it via mongoose set up service. 
         console.log("Launched Mongoose run with run ID: ", mongooseRunId);
+        
+        // NOTE: Loading spinning bar. It will disappear once Mongoose run will be loaded.
         this.mongooseDataSharedServiceService.shouldWaintForNewRun = true; 
+
         // NOTE: If run ID has been returned from the server, Mongoose run has started
         let hasMongooseSuccessfullyStarted = (mongooseRunId != undefined);
         if (!hasMongooseSuccessfullyStarted) {


### PR DESCRIPTION
- Before Mongoose starts to actually export metrics into Prometheus, the progress spinner should be shown for a started run.

Related JIRA's task: https://mongoose-issues.atlassian.net/projects/GUI/issues/GUI-135