### PR TITLE
[GUI-133] Add logarithmic scaling to charts.

### DIFF
--- a/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-options.ts
+++ b/console/src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-options.ts
@@ -90,6 +90,17 @@ export class MongooseChartOptions {
         }
     }
 
+    public isAxisScaledLogarithmically(axis: MongooseChartAxesType): boolean { 
+        switch (axis) {
+            case (MongooseChartAxesType.Y): {
+                return (this.scales.yAxes[0].type == MongooseChartOptions.LOGARITHMIC_CHART_TYPE);
+            }
+            default: {
+                throw new Error(`requested axis "${axis}" hasn't been found.`);
+            }
+        }
+    }
+
     /**
      * Title will be displayed above the chart.
      * @param title a title of chart. 

--- a/console/src/app/modules/app-module/components/run-statistics/run-statistics-charts/run-statistics-charts.component.html
+++ b/console/src/app/modules/app-module/components/run-statistics/run-statistics-charts/run-statistics-charts.component.html
@@ -6,7 +6,7 @@
   </li>
 </ul>
 
-<div class="custom-control custom-switch">
+<div class="custom-control custom-switch" style="margin-left: calc(2%);">
     <input #logarithmicScalingSwitch type="checkbox" class="custom-control-input" id="logarithmicScalingSwitch" (click)="onSwitchStateChange()">
     <label class="custom-control-label" for="logarithmicScalingSwitch">Logarithmic scaling</label>
   </div>

--- a/console/src/app/modules/app-module/components/run-statistics/run-statistics-charts/run-statistics-charts.component.html
+++ b/console/src/app/modules/app-module/components/run-statistics/run-statistics-charts/run-statistics-charts.component.html
@@ -7,7 +7,7 @@
 </ul>
 
 <div class="custom-control custom-switch">
-    <input type="checkbox" class="custom-control-input" id="logarithmicScalingSwitch" (click)="onSwitchStateChange()">
+    <input #logarithmicScalingSwitch type="checkbox" class="custom-control-input" id="logarithmicScalingSwitch" (click)="onSwitchStateChange()">
     <label class="custom-control-label" for="logarithmicScalingSwitch">Logarithmic scaling</label>
   </div>
 

--- a/console/src/app/modules/app-module/components/run-statistics/run-statistics-charts/run-statistics-charts.component.html
+++ b/console/src/app/modules/app-module/components/run-statistics/run-statistics-charts/run-statistics-charts.component.html
@@ -6,12 +6,16 @@
   </li>
 </ul>
 
+<div class="custom-control custom-switch">
+    <input type="checkbox" class="custom-control-input" id="logarithmicScalingSwitch" (click)="onSwitchStateChange()">
+    <label class="custom-control-label" for="logarithmicScalingSwitch">Logarithmic scaling</label>
+  </div>
 
 <!-- NOTE: Area for displaying Mongoose charts -->
 <div id="displaying-charts-area" class="card">
   <div class="card-body">
     <!-- NOTE: Actual chart -->
-    <template #chartContainer ></template>
+    <template #chartContainer ></template>g8
   </div>
 </div>
 

--- a/console/src/app/modules/app-module/components/run-statistics/run-statistics-charts/run-statistics-charts.component.ts
+++ b/console/src/app/modules/app-module/components/run-statistics/run-statistics-charts/run-statistics-charts.component.ts
@@ -109,6 +109,9 @@ export class RunStatisticsChartsComponent implements OnInit {
     return this.chartTabs;
   }
 
+  public onSwitchStateChange() { 
+    alert(`Switch state change`)
+  }
   // MARK: - Private 
 
   private configureChartsRepository() {

--- a/console/src/app/modules/app-module/components/run-statistics/run-statistics-charts/run-statistics-charts.component.ts
+++ b/console/src/app/modules/app-module/components/run-statistics/run-statistics-charts/run-statistics-charts.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, ViewContainerRef, ComponentFactoryResolver } from "@angular/core";
+import { Component, OnInit, ViewChild, ViewContainerRef, ComponentFactoryResolver, ElementRef } from "@angular/core";
 import { MongooseChart } from "src/app/core/models/chart/mongoose-chart-interface/mongoose-chart.interface";
 import { Subscription } from "rxjs";
 import { MongooseRunRecord } from "src/app/core/models/run-record.model";
@@ -10,6 +10,7 @@ import { MongooseRouteParamsParser } from "src/app/core/models/mongoose-route-pa
 import { RoutesList } from "../../../Routing/routes-list";
 import { BasicChartComponent } from "./basic-chart/basic-chart.component";
 import { MongooseRunStatus } from "src/app/core/models/mongoose-run-status";
+import { MongooseChartOptions, MongooseChartAxesType } from "src/app/core/models/chart/mongoose-chart-interface/mongoose-chart-options";
 
 
 
@@ -23,6 +24,7 @@ import { MongooseRunStatus } from "src/app/core/models/mongoose-run-status";
 export class RunStatisticsChartsComponent implements OnInit {
 
   @ViewChild('chartContainer', { read: ViewContainerRef }) chartContainerReference: ViewContainerRef;
+  @ViewChild('logarithmicScalingSwitch') logarithmicScalingSwitch: ElementRef; 
 
   public displayingMongooseChart: MongooseChart;
 
@@ -102,6 +104,7 @@ export class RunStatisticsChartsComponent implements OnInit {
 
     const selectedTabName = selectedTab.getName() as string;
     this.displayingMongooseChart = this.availableCharts.get(selectedTabName);
+    this.logarithmicScalingSwitch.nativeElement.checked = this.isLogarithmicScalingSwitchChecked();
     this.createChartComponent(this.displayingMongooseChart);
   }
 
@@ -110,7 +113,18 @@ export class RunStatisticsChartsComponent implements OnInit {
   }
 
   public onSwitchStateChange() { 
-    alert(`Switch state change`)
+    const isChartScaledLogarithmically: boolean = this.isLogarithmicScalingSwitchChecked();
+    const updatedChartType: string = isChartScaledLogarithmically ? MongooseChartOptions.CHART_DEFAULT_TYPE : MongooseChartOptions.LOGARITHMIC_CHART_TYPE;
+    const yAxis: MongooseChartAxesType = MongooseChartAxesType.Y;
+    let updatedChartComponent: MongooseChart = this.displayingMongooseChart;
+    updatedChartComponent.chartOptions.setAxisChartType(updatedChartType, yAxis);
+    this.createChartComponent(updatedChartComponent);
+  }
+
+  public isLogarithmicScalingSwitchChecked(): boolean { 
+    const yAxis: MongooseChartAxesType = MongooseChartAxesType.Y;
+    console.log(`has log scaling: ${this.displayingMongooseChart.chartOptions.isAxisScaledLogarithmically(yAxis)}`)
+    return this.displayingMongooseChart.chartOptions.isAxisScaledLogarithmically(yAxis);
   }
   // MARK: - Private 
 
@@ -194,6 +208,7 @@ export class RunStatisticsChartsComponent implements OnInit {
     const factory = this.resolver.resolveComponentFactory(BasicChartComponent);
     const chartComponentReference = this.chartContainerReference.createComponent(factory);
     chartComponentReference.instance.chart = this.displayingMongooseChart;
+    this.logarithmicScalingSwitch.nativeElement.checked = this.isLogarithmicScalingSwitchChecked();
   }
 
   private drawDynamicChart(record: MongooseRunRecord) {


### PR DESCRIPTION
Every chart should have an option to scale logarithmically (only Y axis for now). The options should be available from the UI via switch-toggle.

Related JIRA's task: https://mongoose-issues.atlassian.net/projects/GUI/issues/GUI-133