### PR TITLE
[GUI-158] Get container server's address from browser address bar.

### DIFF
--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -113,8 +113,7 @@ export class MongooseSetUpService {
         const portAndAddressDelimiter = ":";
         let prometheusAddressParams: string[] = prometheusAddressWithPort.split(portAndAddressDelimiter);
         const prometheusAddress: string = prometheusAddressParams[0] || environment.prometheusIp;
-        const prometheusPort: string = prometheusAddress[1] || environment.prometheusPort;
-        console.log(`nodes will be added to target on ${prometheusAddress} ${prometheusPort}`)
+        var prometheusPort: string = prometheusAddressParams[1] || environment.prometheusPort;
         this.addNodesToPrometheusTargets(prometheusAddress, prometheusPort, mongooseRunNodesList);
       }
     )


### PR DESCRIPTION
It's unusable to perform HTTP requests to "localhost" since the browser is running on user's node, and the container deploys on another. Fetching UI's address from the address bar, it's possible to get the correct address.

Related JIRA's task: https://mongoose-issues.atlassian.net/projects/GUI/issues/GUI-158