### PR TITLE
[GUI-159] Add progress bar on run table load.

### DIFF
--- a/console/src/app/modules/app-module/components/runs-table/runs-table-root/runs-table-root.component.html
+++ b/console/src/app/modules/app-module/components/runs-table/runs-table-root/runs-table-root.component.html
@@ -13,14 +13,12 @@
 
 
 <ng-container *ngIf="this.hasRunTableInitialized(); else loadingSpinner">
-      <div *ngIf="shouldDisplayRecords(); else emptyRecordsAlert">
-            <!-- NOTE: Table of Mongoose Run Records with actual information. -->
-            <app-runs-table [mongooseRunRecords]="this.getDesiredRecords()" [@slide]="this.displayingRunRecords">
-            </app-runs-table>
-         </div>
+   <div *ngIf="shouldDisplayRecords(); else emptyRecordsAlert">
+      <!-- NOTE: Table of Mongoose Run Records with actual information. -->
+      <app-runs-table [mongooseRunRecords]="this.getDesiredRecords()" [@slide]="this.displayingRunRecords">
+      </app-runs-table>
+   </div>
 </ng-container>
-
-
 
 
 <!-- NOTE: Alert if no Mongoose Run records have been found. -->
@@ -31,7 +29,14 @@
 </ng-template>
 
 <ng-template #loadingSpinner>
-   <div class="spinner-border m-5" role="status">
-      <span class="sr-only">Loading...</span>
+   <!-- NOTE: Loading spinner. It should be displaying until any data will ...
+      ... be received from data provider. -->
+   <div class="alert alert-secondary" role="alert">
+      <div class="d-flex justify-content-center">
+         <button class="btn" disabled>
+            <span class="spinner-border spinner-border-sm"></span>
+            {{ this.RUN_TABLE_LOADING_MSG }}
+         </button>
+      </div>
    </div>
 </ng-template>

--- a/console/src/app/modules/app-module/components/runs-table/runs-table-root/runs-table-root.component.html
+++ b/console/src/app/modules/app-module/components/runs-table/runs-table-root/runs-table-root.component.html
@@ -1,28 +1,37 @@
-
-
 <!-- MARK: - Error message in case of services unavailability -->
 <template #errorMessageComponent></template>
 
 <!-- MARK: - Runs table tabs -->
 <nav class="navbar navbar-light bg-light">
    <form class="form-inline">
-      <button *ngFor="let tab of this.getMongooseRunTabs() | async" class="btn btn-sm btn-outline-secondary" type="button" (click)="onStatusTabClick(tab)"
-         [id]="tab.isSelected ? 'selected-tab' : ''">
+      <button *ngFor="let tab of this.getMongooseRunTabs() | async" class="btn btn-sm btn-outline-secondary"
+         type="button" (click)="onStatusTabClick(tab)" [id]="tab.isSelected ? 'selected-tab' : ''">
          {{ tab.getTabTag() }}
       </button>
    </form>
 </nav>
 
 
-<div *ngIf="shouldDisplayRecords(); else emptyRecordsAlert">
-   <!-- NOTE: Table of Mongoose Run Records with actual information. -->
-   <app-runs-table [mongooseRunRecords]="this.getDesiredRecords()" [@slide]="this.displayingRunRecords"></app-runs-table>
-</div>
+<ng-container *ngIf="this.hasRunTableInitialized(); else loadingSpinner">
+      <div *ngIf="shouldDisplayRecords(); else emptyRecordsAlert">
+            <!-- NOTE: Table of Mongoose Run Records with actual information. -->
+            <app-runs-table [mongooseRunRecords]="this.getDesiredRecords()" [@slide]="this.displayingRunRecords">
+            </app-runs-table>
+         </div>
+</ng-container>
+
+
 
 
 <!-- NOTE: Alert if no Mongoose Run records have been found. -->
 <ng-template #emptyRecordsAlert>
    <div class="alert alert-secondary" role="alert">
       No records yet.
+   </div>
+</ng-template>
+
+<ng-template #loadingSpinner>
+   <div class="spinner-border m-5" role="status">
+      <span class="sr-only">Loading...</span>
    </div>
 </ng-template>

--- a/console/src/app/modules/app-module/components/runs-table/runs-table-root/runs-table-root.component.ts
+++ b/console/src/app/modules/app-module/components/runs-table/runs-table-root/runs-table-root.component.ts
@@ -23,6 +23,8 @@ import { PrometheusApiService } from "src/app/core/services/prometheus-api/prome
 export class RunsTableRootComponent implements OnInit {
 
   @ViewChild('errorMessageComponent', { read: ViewContainerRef }) errorMessageComponent: ViewContainerRef;
+
+  public readonly RUN_TABLE_LOADING_MSG = "Loading runs table...";
   // NOTE: Each tab displays the specific Mongoose Run Records based on record's status. 
   public runTabs: MongooseRunTab[] = [];
   public currentActiveTab: MongooseRunTab;
@@ -37,7 +39,7 @@ export class RunsTableRootComponent implements OnInit {
   private monitoringApiServiceSubscriptions: Subscription = new Subscription();
   private recordUpdatingTimer: any;
 
-  private hasReceivedDataFromProvider: boolean = false; 
+  private hasReceivedDataFromProvider: boolean = false;
   private hasInitializedRecord: boolean = false;
   private errorComponentsReferences: ComponentRef<any>[] = [];
 
@@ -71,7 +73,7 @@ export class RunsTableRootComponent implements OnInit {
    * Determines if data required for Run Table loading has been received.
    * @returns true if data has been successfully loaded from data provider.
    */
-  public hasRunTableInitialized(): boolean { 
+  public hasRunTableInitialized(): boolean {
     return this.hasReceivedDataFromProvider;
   }
   // MARK: - Public 
@@ -202,12 +204,12 @@ export class RunsTableRootComponent implements OnInit {
   /**
    * Defines initial state of run table root component.
    */
-  private setupComponent() { 
+  private setupComponent() {
     this.mongooseRecordsSubscription.add(
       // NOTE: Healthcheck helps prevent situation when error component is displaying until Prometheus' ...
       // ... address actually gets loaded from local storage.
       this.prometheusApiService.isAvailable().subscribe(
-        (isPrometheusAvailable: boolean) => { 
+        (isPrometheusAvailable: boolean) => {
           this.setUpRecordsData();
         }
       )
@@ -239,12 +241,12 @@ export class RunsTableRootComponent implements OnInit {
     )
   }
 
-    /**
-   * Observles any launched Mongoose run. 
-   * It's useful when Mongoose run has been launched but its data ..
-   * ... hasn't been exported to data provider yet. This way we're able to notify...
-   * ... user that the run is still there, but need to be loaded.
-   */
+  /**
+ * Observles any launched Mongoose run. 
+ * It's useful when Mongoose run has been launched but its data ..
+ * ... hasn't been exported to data provider yet. This way we're able to notify...
+ * ... user that the run is still there, but need to be loaded.
+ */
   private observeLaunchedRunRecord() {
     this.monitoringApiService.getMongooseRunRecords().subscribe(
       (fetchedRecord: MongooseRunRecord[]) => {

--- a/console/src/app/modules/app-module/components/runs-table/runs-table-root/runs-table-root.component.ts
+++ b/console/src/app/modules/app-module/components/runs-table/runs-table-root/runs-table-root.component.ts
@@ -37,6 +37,7 @@ export class RunsTableRootComponent implements OnInit {
   private monitoringApiServiceSubscriptions: Subscription = new Subscription();
   private recordUpdatingTimer: any;
 
+  private hasReceivedDataFromProvider: boolean = false; 
   private hasInitializedRecord: boolean = false;
   private errorComponentsReferences: ComponentRef<any>[] = [];
 
@@ -65,14 +66,13 @@ export class RunsTableRootComponent implements OnInit {
     this.mongooseRunTabs$.unsubscribe();
   }
 
-  private observeLaunchedRunRecord() {
-    this.monitoringApiService.getMongooseRunRecords().subscribe(
-      (fetchedRecord: MongooseRunRecord[]) => {
-        if (fetchedRecord.length != this.filtredRecords$.getValue().length) {
-          this.mongooseDataSharedServiceService.shouldWaintForNewRun = false;
-        }
-      }
-    );
+
+  /**
+   * Determines if data required for Run Table loading has been received.
+   * @returns true if data has been successfully loaded from data provider.
+   */
+  public hasRunTableInitialized(): boolean { 
+    return this.hasReceivedDataFromProvider;
   }
   // MARK: - Public 
 
@@ -226,6 +226,7 @@ export class RunsTableRootComponent implements OnInit {
         this.mongooseRunTabs$.next(runTableTabs);
         // NOTE: Displaying every fetched records.
         this.displayingRunRecords = updatedRecords;
+        this.hasReceivedDataFromProvider = true;
       },
       error => {
         this.showErrorComponent(error);
@@ -236,6 +237,22 @@ export class RunsTableRootComponent implements OnInit {
         console.error(misleadingMsg + errorDetails);
       }
     )
+  }
+
+    /**
+   * Observles any launched Mongoose run. 
+   * It's useful when Mongoose run has been launched but its data ..
+   * ... hasn't been exported to data provider yet. This way we're able to notify...
+   * ... user that the run is still there, but need to be loaded.
+   */
+  private observeLaunchedRunRecord() {
+    this.monitoringApiService.getMongooseRunRecords().subscribe(
+      (fetchedRecord: MongooseRunRecord[]) => {
+        if (fetchedRecord.length != this.filtredRecords$.getValue().length) {
+          this.mongooseDataSharedServiceService.shouldWaintForNewRun = false;
+        }
+      }
+    );
   }
 
 }

--- a/console/src/app/modules/app-module/components/runs-table/runs-table.component.html
+++ b/console/src/app/modules/app-module/components/runs-table/runs-table.component.html
@@ -5,7 +5,7 @@
   <thead class="thead-light">
     <tr>
       <th scope="col" *ngFor="let header of columnHeaders" style="white-space: nowrap;">
-          <p style="word-wrap: break-word; width: 100%"> {{ header }} </p>
+        <p style="word-wrap: break-word; width: 100%"> {{ header }} </p>
 
       </th>
     </tr>
@@ -13,20 +13,20 @@
 
   <!-- MARK: - Column content -->
 
- 
+
   <tbody>
-   <tr *ngIf="this.shouldAppearLoadSpinner()">
-     <!-- NOTE: Colspan should be equal to amount of overlaying columns. -->
+    <tr *ngIf="this.shouldAppearLoadSpinner()">
+      <!-- NOTE: Colspan should be equal to amount of overlaying columns. -->
       <td align="center" colspan="5">
-          <!-- NOTE: Loading spinner. It appears if a Mongoose run has been launched, but its metrics ...
+        <!-- NOTE: Loading spinner. It appears if a Mongoose run has been launched, but its metrics ...
           ... weren't exported to Prometheus yet. -->
-          <button class="btn btn-light" style="width: calc(70%);">
-              <span class="spinner-border spinner-border-sm"></span>
-              {{ this.MONGOOSE_LOADING_RUN_MSG }}
-            </button>
-        </td>
-   </tr>
-    
+        <button class="btn btn-light" style="width: calc(70%);" disabled>
+          <span class="spinner-border spinner-border-sm"></span>
+          {{ this.MONGOOSE_LOADING_RUN_MSG }}
+        </button>
+      </td>
+    </tr>
+
     <tr *ngFor="let runRecord of mongooseRunRecords">
       <th scope="row">
         <app-mongoose-run-status-icon [runStatus]="runRecord.getStatus()" (click)="onRunStatusIconClicked(runRecord)">


### PR DESCRIPTION
**Now**: the user will see "No runs yet" widget in case run table is empty. If loading of the runs is still being processed, the table will be displaying as empty.
**Then**: add spinning bar until run table completes its loading.

Related JIRA's task: https://mongoose-issues.atlassian.net/projects/GUI/issues/GUI-159?filter=allopenissues&orderby=priority%20DESC