### PR TITLE
[GUI-163] Change prometheus scraping behaviour.

### DIFF
--- a/console/src/app/common/FileOperations/PrometheusConfigurationEditor.ts
+++ b/console/src/app/common/FileOperations/PrometheusConfigurationEditor.ts
@@ -3,12 +3,13 @@
 
 export class PrometheusConfigurationEditor {
 
+    private readonly JOBNAME_PROPERTY: string = "job_name";
+    private readonly PROMETHEUS_JOBNAME: string = "prometheus";
     private readonly TARGETS_PROPERTY_NAME: string = "targets";
     private readonly SCRAPE_INTERVAL_PROPERTY_NAME: string = "scrape_interval";
     private readonly SCRAPE_TIMEOUT_PROPERTY_NAME: string = "scrape_timeout";
 
     private readonly CONFIGURATION_FIELD_AND_VALUE_DELIMITER: string = "  ";
-    
     private readonly TARGET_LIST_ELEMENTS_SURROUNDING_CHARACTERS = "'";
 
     public prometheusConfigurationFileContent: Object;
@@ -56,7 +57,7 @@ export class PrometheusConfigurationEditor {
      */
     public changeScrapeInterval(prometheusConfiguration: String, periodOfScrapeSecs: number): String {
         const periodOfScrapeSecondsPropertyValue: string = `${periodOfScrapeSecs}s`;
-        return this.changeFirstFoundPropertyValue(prometheusConfiguration, this.SCRAPE_INTERVAL_PROPERTY_NAME, periodOfScrapeSecondsPropertyValue);
+        return this.changeLastFoundPropertyValue(prometheusConfiguration, this.SCRAPE_INTERVAL_PROPERTY_NAME, periodOfScrapeSecondsPropertyValue);
     }
 
 
@@ -69,20 +70,19 @@ export class PrometheusConfigurationEditor {
      */
     public changeScrapeTimeout(prometheusConfiguration: String, scrapeTimeoutSecs: number): String {
         const scrapeTimeoutSecondsPropertyValue: string = `${scrapeTimeoutSecs}s`;
-        return this.changeFirstFoundPropertyValue(prometheusConfiguration, this.SCRAPE_TIMEOUT_PROPERTY_NAME, scrapeTimeoutSecondsPropertyValue);
+        return this.changeLastFoundPropertyValue(prometheusConfiguration, this.SCRAPE_TIMEOUT_PROPERTY_NAME, scrapeTimeoutSecondsPropertyValue);
     }
-
 
     // MARK: - Private 
 
     /**
-     * Changes value of property that was first to be found by provided name.
+     * Changes value of last found property with a specified name.
      * @param prometheusConfiguration processing Prometheus configuration.
      * @param propertyName name of property for chaning. IMPORTANT: Name should be provided WITH the postfix if needed. (e.g.: "10s" should be provided as "10s", not just "10").
      * @param propertyValue updated property value.
      * @returns configuration with updated property value.
      */
-    private changeFirstFoundPropertyValue(prometheusConfiguration: String, propertyName: string, propertyValue: string): String {
+    private changeLastFoundPropertyValue(prometheusConfiguration: String, propertyName: string, propertyValue: string): String {
         const startIndexOfPropetySection: number = prometheusConfiguration.toString().lastIndexOf(propertyName);
 
         var hasReachedEndOfLine: boolean = false;

--- a/console/src/app/common/FileOperations/PrometheusConfigurationEditor.ts
+++ b/console/src/app/common/FileOperations/PrometheusConfigurationEditor.ts
@@ -1,5 +1,3 @@
-import { start } from "repl";
-
 // NOTE: class should edit Prometheus' configuration. It was created because ...
 // ... I haven't found a good TypeScript-cpmpatible library to parse .yml file. 
 

--- a/console/src/app/common/FileOperations/PrometheusConfigurationEditor.ts
+++ b/console/src/app/common/FileOperations/PrometheusConfigurationEditor.ts
@@ -3,8 +3,10 @@
 
 export class PrometheusConfigurationEditor {
 
-    private readonly TARGETS_PROPERTY_NAME = "targets";
-    private readonly SCRAPE_INTERVAL_PROPERTY_NAME = "scrape_interval";
+    private readonly TARGETS_PROPERTY_NAME: string = "targets";
+    private readonly SCRAPE_INTERVAL_PROPERTY_NAME: string = "scrape_interval";
+    private readonly CONFIGURATION_FIELD_AND_VALUE_DELIMITER: string = "  ";
+    
     private readonly TARGET_LIST_ELEMENTS_SURROUNDING_CHARACTERS = "'";
 
     public prometheusConfigurationFileContent: Object;
@@ -74,7 +76,7 @@ export class PrometheusConfigurationEditor {
         // NOTE: Inserting updated value between startIndex and endIndex.
         var updatedConfiguration: string = prometheusConfiguration.substring(0, startIndexOfPropetySection);
 
-        const newPropertyValue: string = `${propertyName}:${propertyValue}\n`;
+        const newPropertyValue: string = `${propertyName}:${this.CONFIGURATION_FIELD_AND_VALUE_DELIMITER}${propertyValue}\n`;
         updatedConfiguration += newPropertyValue;
 
         const lastIndexOfProvidedConfiguration: number = prometheusConfiguration.length;
@@ -103,8 +105,7 @@ export class PrometheusConfigurationEditor {
 
     private getUpdatedTargetsValue(targets: String[]): String {
         targets = this.surroundListItemsWithCharacter(targets, this.TARGET_LIST_ELEMENTS_SURROUNDING_CHARACTERS);
-        let fieldNameAndValueDelimiter = "  "; // NOTE: prometheus.yml file delimiter contains 2 whitesapces
         // NOTE: Targets property and value must retain delimiter. Prometheus will crash otherwise.
-        return `${this.TARGETS_PROPERTY_NAME}:${fieldNameAndValueDelimiter}[${targets}]`
+        return `${this.TARGETS_PROPERTY_NAME}:${this.CONFIGURATION_FIELD_AND_VALUE_DELIMITER}[${targets}]`
     }
 }

--- a/console/src/app/common/FileOperations/PrometheusConfigurationEditor.ts
+++ b/console/src/app/common/FileOperations/PrometheusConfigurationEditor.ts
@@ -5,6 +5,8 @@ export class PrometheusConfigurationEditor {
 
     private readonly TARGETS_PROPERTY_NAME: string = "targets";
     private readonly SCRAPE_INTERVAL_PROPERTY_NAME: string = "scrape_interval";
+    private readonly SCRAPE_TIMEOUT_PROPERTY_NAME: string = "scrape_timeout";
+
     private readonly CONFIGURATION_FIELD_AND_VALUE_DELIMITER: string = "  ";
     
     private readonly TARGET_LIST_ELEMENTS_SURROUNDING_CHARACTERS = "'";
@@ -45,9 +47,29 @@ export class PrometheusConfigurationEditor {
         return finalConfiguration;
     }
 
+    /**
+     * Changes scrape interval in Prometheus' configuration. 
+     * Note: it changes the scrape interval value only within the first found field since it's usually global.
+     * @param prometheusConfiguration Prometheus' configuration.
+     * @param periodOfScrapeSecs Period of data scraping to be set into the configuration.
+     * @returns updated Prometheus configuration.
+     */
     public changeScrapeInterval(prometheusConfiguration: String, periodOfScrapeSecs: number): String {
         const periodOfScrapeSecondsPropertyValue: string = `${periodOfScrapeSecs}s`;
         return this.changeFirstFoundPropertyValue(prometheusConfiguration, this.SCRAPE_INTERVAL_PROPERTY_NAME, periodOfScrapeSecondsPropertyValue);
+    }
+
+
+    /**
+     * Changes scrape timeout in Prometheus' configuration. 
+     * Note: it changes the scrape interval value only within the first found field since it's usually global.
+     * @param prometheusConfiguration Prometheus' configuration.
+     * @param scrapeTimeoutSecs Period of data scrape request timeout to be set into the configuration.
+     * @returns updated Prometheus configuration.
+     */
+    public changeScrapeTimeout(prometheusConfiguration: String, scrapeTimeoutSecs: number): String {
+        const scrapeTimeoutSecondsPropertyValue: string = `${scrapeTimeoutSecs}s`;
+        return this.changeFirstFoundPropertyValue(prometheusConfiguration, this.SCRAPE_TIMEOUT_PROPERTY_NAME, scrapeTimeoutSecondsPropertyValue);
     }
 
 

--- a/console/src/app/core/services/container-server/container-server-service.ts
+++ b/console/src/app/core/services/container-server/container-server-service.ts
@@ -48,11 +48,11 @@ export class ContainerServerService {
     }
 
     /**
- * Fetches current deploying address from browser's address bar.
- * It was done in order to perform HTTP requests to NodeJS proxy server.
- * @deprecated if NodeJS isn't using anymore.
- * @returns current deploying address with HTTP prefix.
- */
+     * Fetches current deploying address from browser's address bar.
+     * It was done in order to perform HTTP requests to NodeJS proxy server.
+     * @deprecated if NodeJS isn't using anymore.
+     * @returns current deploying address with HTTP prefix.
+     */
     public getContainerServicerAddressFromAddressLine(): string {
         let rawLocation = (document.location as unknown);
         var currentUrl: string = String(rawLocation);

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -145,9 +145,10 @@ export class MongooseSetUpService {
     // NOTE: An initial fetch of Prometheus configuration.
     this.http.get(environment.prometheusConfigPath, { responseType: 'text' }).subscribe((configurationFileContent: Object) => {
       let prometheusConfigurationEditor: PrometheusConfigurationEditor = new PrometheusConfigurationEditor(configurationFileContent);
-      
+
       // NOTE: Appending configuration with added Mongoose nodes.
       var updatedConfiguration = prometheusConfigurationEditor.addTargetsToConfiguration(mongooseRunNodes);
+      console.log(`Provided configuration: ${updatedConfiguration}`);
 
       // NOTE: changing scrape interval in order to provide better response for elements that are dependent ...
       // ... on the metrics.
@@ -155,6 +156,8 @@ export class MongooseSetUpService {
 
       // NOTE: Changing scrape timeout within Prometheus configuration in order to exclude connection-related errors.
       updatedConfiguration = prometheusConfigurationEditor.changeScrapeTimeout(updatedConfiguration, this.DEFAULT_DATA_SCRAPE_TIMEOUT_SECS);
+
+      console.log(`\n ######## Updated configuration: ${updatedConfiguration}`);
 
       // NOTE: Saving prometheus configuration in .yml file. 
       let prometheusConfigFileName = `${Constants.FileNames.PROMETHEUS_CONFIGURATION}.${FileFormat.YML}`;

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -146,7 +146,7 @@ export class MongooseSetUpService {
       let prometheusConfigurationEditor: PrometheusConfigurationEditor = new PrometheusConfigurationEditor(configurationFileContent);
       
       // NOTE: Appending configuration with added Mongoose nodes.
-      let updatedConfiguration = prometheusConfigurationEditor.addTargetsToConfiguration(mongooseRunNodes);
+      var updatedConfiguration = prometheusConfigurationEditor.addTargetsToConfiguration(mongooseRunNodes);
 
       // NOTE: Changing scraping interval within Prometheus configuration in order to exclude connection-related errors.
       updatedConfiguration = prometheusConfigurationEditor.changeScrapeInterval(updatedConfiguration, this.DEFAULT_PROMETHEUS_SCRAPING_INTERVAL_SECS);

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -21,7 +21,8 @@ import { PrometheusApiService } from '../prometheus-api/prometheus-api.service';
 })
 export class MongooseSetUpService {
 
-  private readonly DEFAULT_PROMETHEUS_SCRAPING_INTERVAL_SECS: number = 5;
+  private readonly DEFAULT_DATA_SCRAPE_INTERVAL_SECS: number = 5;
+  private readonly DEFAULT_DATA_SCRAPE_TIMEOUT_SECS: number = 30;
 
   private mongooseSetupInfoModel: MongooseSetupInfoModel;
 
@@ -148,8 +149,12 @@ export class MongooseSetUpService {
       // NOTE: Appending configuration with added Mongoose nodes.
       var updatedConfiguration = prometheusConfigurationEditor.addTargetsToConfiguration(mongooseRunNodes);
 
-      // NOTE: Changing scraping interval within Prometheus configuration in order to exclude connection-related errors.
-      updatedConfiguration = prometheusConfigurationEditor.changeScrapeInterval(updatedConfiguration, this.DEFAULT_PROMETHEUS_SCRAPING_INTERVAL_SECS);
+      // NOTE: changing scrape interval in order to provide better response for elements that are dependent ...
+      // ... on the metrics.
+      updatedConfiguration = prometheusConfigurationEditor.changeScrapeInterval(updatedConfiguration, this.DEFAULT_DATA_SCRAPE_INTERVAL_SECS);
+
+      // NOTE: Changing scrape timeout within Prometheus configuration in order to exclude connection-related errors.
+      updatedConfiguration = prometheusConfigurationEditor.changeScrapeTimeout(updatedConfiguration, this.DEFAULT_DATA_SCRAPE_TIMEOUT_SECS);
 
       // NOTE: Saving prometheus configuration in .yml file. 
       let prometheusConfigFileName = `${Constants.FileNames.PROMETHEUS_CONFIGURATION}.${FileFormat.YML}`;

--- a/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
+++ b/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
@@ -366,7 +366,7 @@ export class PrometheusApiService implements MongooseChartDataProvider {
     var currentHostAddress: string = this.containerServerService.getContainerServicerAddressFromAddressLine();
 
     const hostAddressContainsHttpPrefix: boolean = currentHostAddress.includes(Constants.Http.HTTP_PREFIX);
-    if (hostAddressContainsHttpPrefix) { 
+    if (hostAddressContainsHttpPrefix) {
       // NOTE: Pruning HTTP prefix for easier parsing.
       currentHostAddress = HttpUtils.pruneHttpPrefixFromAddress(currentHostAddress);
     }

--- a/console/src/assets/configuration-examples/prometheus/prometheus.yml
+++ b/console/src/assets/configuration-examples/prometheus/prometheus.yml
@@ -2,7 +2,7 @@
 global:
   scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
-  # scrape_timeout is set to the global default (10s).
+  scrape_timeout: 0s # is set to the global default (10s).
 
 # Alertmanager configuration
 alerting:

--- a/console/src/assets/configuration-examples/prometheus/prometheus.yml
+++ b/console/src/assets/configuration-examples/prometheus/prometheus.yml
@@ -2,7 +2,6 @@
 global:
   scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
-  scrape_timeout: 0s # is set to the global default (10s).
 
 # Alertmanager configuration
 alerting:


### PR DESCRIPTION
**Description**

**Now**: Prometheus' configuration is being modified only in "hosts". The scrape timeout is set to 10 seconds - this period could be too small while deploying in Kubernetes. Also, scrape interval is 15 seconds, which is also not good for dynamic chart drawing.
**Then**: Prometheus' scrape timeout should be set to 30 seconds. Scrape interval should be 5 seconds.
IMPORTANT: the changes should be applied once user has clicked "run" button. Otherwise it'll be highly error-prone implementation since the configuration will be changing on every page reload.

Related JIRA's task: https://mongoose-issues.atlassian.net/browse/GUI-163 