### PR TITLE
[GUI-165] Add timeout to Mongoose health checks.

### DIFF
--- a/console/src/app/common/FileOperations/PrometheusConfigurationEditor.ts
+++ b/console/src/app/common/FileOperations/PrometheusConfigurationEditor.ts
@@ -32,16 +32,26 @@ export class PrometheusConfigurationEditor {
         let startIndexOfTargetsSection: number = processingConfiguration.toString().lastIndexOf(this.TARGETS_PROPERTY_NAME);
 
         let isEndOfLine: boolean = false;
+        const targetListBeginSymbol: string = "[";
         var endIndexOfTargetsSection: number = startIndexOfTargetsSection;
+        var amountOfCharsUntilTargetsListStart: number = 0;
         while (!isEndOfLine) {
-            let nextChar = processingConfiguration[endIndexOfTargetsSection + 1];
             endIndexOfTargetsSection++;
-            isEndOfLine = (nextChar == "\n");
+            let currentChar: string = processingConfiguration[endIndexOfTargetsSection];
+            isEndOfLine = ((currentChar == targetListBeginSymbol));
         }
+        endIndexOfTargetsSection++;
 
-        let firstPartOfConfiguration = processingConfiguration.substring(0, startIndexOfTargetsSection);
-        firstPartOfConfiguration += this.getUpdatedTargetsValue(targets);
-        let secondPartOfConfiguration = processingConfiguration.substring(endIndexOfTargetsSection, processingConfiguration.length);
+        let firstPartOfConfiguration: string = processingConfiguration.substring(0, endIndexOfTargetsSection);
+        console.log(`[add targets] firstPartOfConfiguration: ${firstPartOfConfiguration}`)
+       
+        // NOTE: Temp-fix in order to retain ALL scraped Mongoose's nodes.
+        const targetListEndSymbol: string = "]";
+        const insertingTargetsValue: string = this.getUpdatedTargetsValue(targets).replace(targetListEndSymbol, ",").replace(targetListBeginSymbol, ","); // NOTE: Returns "targets: [...]";
+       
+        firstPartOfConfiguration += insertingTargetsValue;
+        let secondPartOfConfiguration: string = processingConfiguration.substring(endIndexOfTargetsSection, processingConfiguration.length);
+        console.log(`[add targets] secondPartOfConfiguration: ${secondPartOfConfiguration}`)
         let finalConfiguration = firstPartOfConfiguration + secondPartOfConfiguration;
 
         return finalConfiguration;
@@ -199,6 +209,7 @@ export class PrometheusConfigurationEditor {
 
     private getUpdatedTargetsValue(targets: String[]): String {
         targets = this.surroundListItemsWithCharacter(targets, this.TARGET_LIST_ELEMENTS_SURROUNDING_CHARACTERS);
+        return `${targets}`; 
         // NOTE: Targets property and value must retain delimiter. Prometheus will crash otherwise.
         return `${this.TARGETS_PROPERTY_NAME}:${this.CONFIGURATION_FIELD_AND_VALUE_DELIMITER}[${targets}]`
     }

--- a/console/src/app/common/FileOperations/PrometheusConfigurationEditor.ts
+++ b/console/src/app/common/FileOperations/PrometheusConfigurationEditor.ts
@@ -47,9 +47,12 @@ export class PrometheusConfigurationEditor {
        
         // NOTE: Temp-fix in order to retain ALL scraped Mongoose's nodes.
         const targetListEndSymbol: string = "]";
-        const insertingTargetsValue: string = this.getUpdatedTargetsValue(targets).replace(targetListEndSymbol, ",").replace(targetListBeginSymbol, ","); // NOTE: Returns "targets: [...]";
-       
-        firstPartOfConfiguration += insertingTargetsValue;
+        var insertingTargetsValue: string = this.getUpdatedTargetsValue(targets).replace(targetListEndSymbol, ",").replace(targetListBeginSymbol, ","); // NOTE: Returns "targets: [...]";
+        
+        const delimiter: string = `,`;
+        insertingTargetsValue += delimiter;
+        console.log(`insertingTargetsValue: ${JSON.stringify(insertingTargetsValue)}`)
+        firstPartOfConfiguration += insertingTargetsValue
         let secondPartOfConfiguration: string = processingConfiguration.substring(endIndexOfTargetsSection, processingConfiguration.length);
         console.log(`[add targets] secondPartOfConfiguration: ${secondPartOfConfiguration}`)
         let finalConfiguration = firstPartOfConfiguration + secondPartOfConfiguration;
@@ -211,6 +214,6 @@ export class PrometheusConfigurationEditor {
         targets = this.surroundListItemsWithCharacter(targets, this.TARGET_LIST_ELEMENTS_SURROUNDING_CHARACTERS);
         return `${targets}`; 
         // NOTE: Targets property and value must retain delimiter. Prometheus will crash otherwise.
-        return `${this.TARGETS_PROPERTY_NAME}:${this.CONFIGURATION_FIELD_AND_VALUE_DELIMITER}[${targets}]`
+        // return `${this.TARGETS_PROPERTY_NAME}:${this.CONFIGURATION_FIELD_AND_VALUE_DELIMITER}[${targets}]`
     }
 }

--- a/console/src/app/core/services/control-api/control-api.service.ts
+++ b/console/src/app/core/services/control-api/control-api.service.ts
@@ -113,7 +113,7 @@ export class ControlApiService {
       headers: new HttpHeaders(requestRunStatusHeaders),
       observe: 'response' as 'body'
     }
-
+    console.log(`Fetching status for Mongoose run ID ${runEntryNode.getRunId()} on node ${mongooseEntryNodeAddress}`);
     return this.http.get(`http://${mongooseEntryNodeAddress}/${MongooseApi.RunApi.RUN_ENDPOINT}`, runStatusRequestOptions).pipe(
       map((runStatusResponse: any) => {
         let responseStatusCode = runStatusResponse.status;

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -8,7 +8,7 @@ import { HttpClient } from '@angular/common/http';
 import { PrometheusConfigurationEditor } from 'src/app/common/FileOperations/PrometheusConfigurationEditor';
 import { FileFormat } from 'src/app/common/FileOperations/FileFormat';
 import { ContainerServerService } from 'src/app/core/services/container-server/container-server-service';
-import { map } from 'rxjs/operators';
+import { map, timeout } from 'rxjs/operators';
 import { MongooseRunNode } from '../../models/mongoose-run-node.model';
 import { ResourceLocatorType } from '../../models/address-type';
 import { MongooseConfigurationParser } from '../../models/mongoose-configuration-parser';
@@ -94,7 +94,10 @@ export class MongooseSetUpService {
 
 
   public isMongooseNodeActive(mongooseNodeAddress: string): Observable<boolean> {
-    return this.monitoringApiService.isMongooseRunNodeActive(mongooseNodeAddress);
+    const timeoutMilliseconds: number = 2500; // NOTE: Timeout is set to 2.5 seconds 
+    return this.monitoringApiService.isMongooseRunNodeActive(mongooseNodeAddress).pipe(
+      timeout(timeoutMilliseconds)
+    );
   }
 
   // NOTE: Adding Mongoose nodes (while node selection)

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -2,13 +2,13 @@ import { Injectable } from '@angular/core';
 import { MongooseSetupInfoModel } from './mongoose-set-up-info.model';
 import { ControlApiService } from 'src/app/core/services/control-api/control-api.service';
 import { Constants } from 'src/app/common/constants';
-import { Observable, BehaviorSubject } from 'rxjs';
+import { Observable, BehaviorSubject, of } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { HttpClient } from '@angular/common/http';
 import { PrometheusConfigurationEditor } from 'src/app/common/FileOperations/PrometheusConfigurationEditor';
 import { FileFormat } from 'src/app/common/FileOperations/FileFormat';
 import { ContainerServerService } from 'src/app/core/services/container-server/container-server-service';
-import { map, timeout } from 'rxjs/operators';
+import { map, timeout, catchError } from 'rxjs/operators';
 import { MongooseRunNode } from '../../models/mongoose-run-node.model';
 import { ResourceLocatorType } from '../../models/address-type';
 import { MongooseConfigurationParser } from '../../models/mongoose-configuration-parser';
@@ -97,7 +97,12 @@ export class MongooseSetUpService {
     const timeoutMilliseconds: number = 2500; // NOTE: Timeout is set to 2.5 seconds 
     return this.monitoringApiService.isMongooseRunNodeActive(mongooseNodeAddress).pipe(
       timeout(timeoutMilliseconds)
-    );
+    ).pipe(
+      catchError(error => { 
+        console.log(`Mongoose's node ${mongooseNodeAddress} status request has timed out.`);
+        return of(false);
+      })
+    )
   }
 
   // NOTE: Adding Mongoose nodes (while node selection)
@@ -152,11 +157,12 @@ export class MongooseSetUpService {
   private addNodesToPrometheusTargets(prometheusAddress: string, prometheusPort: string, mongooseRunNodes: string[]) {
     // NOTE: An initial fetch of Prometheus configuration.
     this.http.get(environment.prometheusConfigPath, { responseType: 'text' }).subscribe((configurationFileContent: Object) => {
+      console.log(`Provided configuration: ${configurationFileContent}`);
+
       let prometheusConfigurationEditor: PrometheusConfigurationEditor = new PrometheusConfigurationEditor(configurationFileContent);
 
       // NOTE: Appending configuration with added Mongoose nodes.
       var updatedConfiguration = prometheusConfigurationEditor.addTargetsToConfiguration(mongooseRunNodes);
-      console.log(`Provided configuration: ${updatedConfiguration}`);
 
       // NOTE: changing scrape interval in order to provide better response for elements that are dependent ...
       // ... on the metrics.

--- a/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
+++ b/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
@@ -56,7 +56,8 @@ export class MonitoringApiService {
       })
     ).pipe(
       timeout(this.DEFAULT_TIMEOUT_MILLISECS),
-      share(),
+      share()
+    ).pipe(
       catchError(error => {
         console.log(`Request for Mongoose node's status at ${mongooseRunEntryNode.getEntryNodeAddress()} has timed out. Returning status "finished".`);
         return of (MongooseRunStatus.Finished);

--- a/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
+++ b/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 import { Constants } from "src/app/common/constants";
-import { BehaviorSubject, Observable, of } from "rxjs";
+import { BehaviorSubject, Observable, of, TimeoutError } from "rxjs";
 import { MongooseRunRecord } from "../../models/run-record.model";
 import { PrometheusApiService } from "../prometheus-api/prometheus-api.service";
 import { MongooseRunStatus } from "../../models/mongoose-run-status";
@@ -164,6 +164,9 @@ export class MonitoringApiService {
         return true;
       }),
       catchError((error, caughtError) => {
+        if (error instanceof TimeoutError) { 
+          console.log(`Request on Mongoose node ${runNodeAddress} has timed out.`);
+        }
         return of(false);
       })
     );

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-base/mongoose-base-deployment-2.yaml
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-base/mongoose-base-deployment-2.yaml
@@ -1,18 +1,21 @@
+# NOTE: This Kubernetes object was created in testing purposes. ...
+# ... The configuration may be not suitable for you.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: mongoose-base
-  name: mongoose-base-dc
+    app: mongoose-base-deployment-2
+  name: mongoose-base-dc-2
 spec:
   selector:
     matchLabels:
-      app: mongoose-base
+      app: mongoose-base-deployment-2
   replicas: 1 
   template:
     metadata:
       labels:
-        app: mongoose-base
+        app: mongoose-base-deployment-2
     spec:
       containers:
       - name: mongoose-base-1
@@ -34,5 +37,4 @@ spec:
       - name: mongoose-base-5
         image: emcmongoose/mongoose-base
         args: [--run-node, --storage-driver-type=dummy-mock, --run-port=9999, --load-step-node-port=1099]
-
-       
+      

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-base/mongoose-base-deployment.yaml
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-base/mongoose-base-deployment.yaml
@@ -1,18 +1,21 @@
+# NOTE: This Kubernetes object was created in testing purposes. ...
+# ... The configuration may be not suitable for you.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: mongoose-base-deployment-2
-  name: mongoose-base-dc-2
+    app: mongoose-base
+  name: mongoose-base-dc
 spec:
   selector:
     matchLabels:
-      app: mongoose-base-deployment-2
+      app: mongoose-base
   replicas: 1 
   template:
     metadata:
       labels:
-        app: mongoose-base-deployment-2
+        app: mongoose-base
     spec:
       containers:
       - name: mongoose-base-1

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-base/mongoose-base-service-2.yaml
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-base/mongoose-base-service-2.yaml
@@ -1,3 +1,7 @@
+# NOTE: The service connects Mongoose's k8s deployment with the outside network. 
+# ... It has been added in test purposes. The connection with the outside world is required for ...
+# ... healthcheck and overall interaction with the UI (Darzee).
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,6 +11,8 @@ metadata:
 spec:
   ports:
     # NOTE: Exposting ports
+
+    # NOTE: Remote API ports
     - name: nmongoose-base-port-1
       port: 9991
       targetPort: 9991
@@ -23,6 +29,7 @@ spec:
       port: 9999
       targetPort: 9999
       
+    # NOTE: RMI ports
     - name: nmongoose-base-rmi-1
       port: 1091
       targetPort: 1091

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-base/mongoose-base-service.yaml
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-base/mongoose-base-service.yaml
@@ -1,3 +1,7 @@
+# NOTE: The service connects Mongoose's k8s deployment with the outside network. 
+# ... It has been added in test purposes. The connection with the outside world is required for ...
+# ... healthcheck and overall interaction with the UI (Darzee).
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,6 +11,8 @@ metadata:
 spec:
   ports:
     # NOTE: Exposting ports
+
+    # NOTE: Remote API ports 
     - name: nmongoose-base-port-1
       port: 9991
       targetPort: 9991
@@ -23,6 +29,7 @@ spec:
       port: 9999
       targetPort: 9999
       
+    # NOTE: RMI ports
     - name: nmongoose-base-rmi-1
       port: 1091
       targetPort: 1091

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-base/tools/create-mongoose-environment.sh
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-base/tools/create-mongoose-environment.sh
@@ -1,0 +1,4 @@
+kubectl create -f ../mongoose-base-deployment.yaml
+kubectl create -f ../mongoose-base-deployment-2.yaml
+kubectl create -f ../mongoose-base-service.yaml
+kubectl create -f ../mongoose-base-service-2.yaml

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-base/tools/delete-mongoose-environment.sh
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-base/tools/delete-mongoose-environment.sh
@@ -1,0 +1,4 @@
+kubectl delete deployment mongoose-base-dc-1
+kubectl delete deployment mongoose-base-dc-2
+kubectl delete svc mongoose-base-svc
+kubectl delete svc mongoose-base-svc-2

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/mongoose-pravega-deployment.yml
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/mongoose-pravega-deployment.yml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mongoose-pravega
+  name: mongoose-pravega-dc
+spec:
+  selector:
+    matchLabels:
+      app: mongoose-pravega
+  replicas: 1 
+  template:
+    metadata:
+      labels:
+        app: mongoose-pravega
+    spec:
+      containers:
+      - name: mongoose-pravega-master
+        image: emcmongoose/mongoose-storage-driver-pravega
+        args: [--run-node, --storage-namespace=mongoose-pravega-scope, --run-port=9999, --load-step-node-port=1099, 
+          # NOTE: storage-net-node-addrs is address of a Pravega controller. ...
+          # ...The one presented in this configuration was hard-coded in test purposes.
+          --storage-net-node-addrs=175.24.45.7]
+      

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/mongoose-pravega-deployment.yml
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/mongoose-pravega-deployment.yml
@@ -8,7 +8,7 @@ spec:
   selector:
     matchLabels:
       app: mongoose-pravega
-  replicas: 1 
+  replicas: 3
   template:
     metadata:
       labels:

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/mongoose-pravega-deployment.yml
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/mongoose-pravega-deployment.yml
@@ -20,5 +20,5 @@ spec:
         args: [--run-node, --storage-namespace=mongoose-pravega-scope, --run-port=9999, --load-step-node-port=1099, 
           # NOTE: storage-net-node-addrs is address of a Pravega controller. ...
           # ...The one presented in this configuration was hard-coded in test purposes.
-          --storage-net-node-addrs=175.24.45.7]
+          --storage-net-node-addrs=175.24.45.7, --load-batch-size=100, --storage-driver-limit-queue-input=10000]
       

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/mongoose-pravega-service.yml
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/mongoose-pravega-service.yml
@@ -12,6 +12,6 @@ spec:
       port: 9999
       targetPort: 9999
   selector:
-    app: mongoose-pravega-svc
+    app: mongoose-pravega
   type: LoadBalancer
   sessionAffinity: None

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/mongoose-pravega-service.yml
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/mongoose-pravega-service.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mongoose-pravega
+  name: mongoose-pravega-svc
+spec:
+  ports:
+    # NOTE: Exposting ports
+    - name: mongoose-pravega-port
+    # NOTE: Remote API Port
+      port: 9999
+      targetPort: 9999
+  selector:
+    app: mongoose-pravega-svc
+  type: LoadBalancer
+  sessionAffinity: None

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/tools/create-mongoose-pravega-environment.sh
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/tools/create-mongoose-pravega-environment.sh
@@ -1,0 +1,2 @@
+kubectl create -f ../mongoose-pravega-deployment.yaml
+kubectl create -f ../mongoose-pravega-service.yaml

--- a/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/tools/delete-mongoose-pravega-environment.sh
+++ b/console/src/assets/configuration-examples/kubernetes/mongoose-pravega/tools/delete-mongoose-pravega-environment.sh
@@ -1,0 +1,2 @@
+kubectl delete svc mongoose-pravega-svc
+kubectl delete deployment mongoose-pravega-dc


### PR DESCRIPTION
**Description**

**Now**: Mongoose's health checks doesn't have a specified timeout. The health checks for nodes availability could be performed for 1 minute, which is way too longs.
**Then**: timeout for a health check should be set to 10 seconds.

Related JIRA's task: https://mongoose-issues.atlassian.net/projects/GUI/issues/GUI-165