### PR TITLE
[GUI-175-1] Prometheus port doesn't get retrieved.

### DIFF
--- a/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
+++ b/console/src/app/core/services/prometheus-api/prometheus-api.service.ts
@@ -372,10 +372,18 @@ export class PrometheusApiService implements MongooseChartDataProvider {
     }
     const ipAndPortDelimiter: string = ":";
     const ipAddressIndex: number = 0;
-    var prometheusIp: string = currentHostAddress.split(ipAndPortDelimiter)[ipAddressIndex];
 
+    var prometheusIp: string = currentHostAddress.split(ipAndPortDelimiter)[ipAddressIndex];
+   
+    const prometheusPortIndex: number = 1;
+    var prometheusPort: string = currentHostAddress.split(ipAndPortDelimiter)[prometheusPortIndex];
+    if (prometheusPort == undefined) { 
+      // NOTE: When user didn't specify Prometheus port, set the default one.
+      prometheusPort = environment.prometheusPort;
+    }
+    
     // NOTE: Append IP address with default Prometheus port. 
-    prometheusIp = `${prometheusIp}${ipAndPortDelimiter}${environment.prometheusPort}`;
+    prometheusIp = `${prometheusIp}${ipAndPortDelimiter}${prometheusPort}`;
 
     console.log(`Trying to load Prometheus on ${prometheusIp}...`);
 


### PR DESCRIPTION
This PR extends https://github.com/emc-mongoose/darzee/pull/133. 
In case of Prometheus' unavailability, it's possible to specify its address from the UI.

**Current environment**
Address is being parsed correctly while the port status default (from the .env file) all the time.

**Desired environment**
Entered Prometheus' port should be parsed and processed as well.