### PR TITLE
[GUI-176-1] Replace custom checkbox for nodes selection.

### DIFF
--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -1915,6 +1915,11 @@
         "multicast-dns-service-types": "^1.1.0"
       }
     },
+    "bootstrap": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
+    },
     "brace": {
       "version": "0.11.1",
       "resolved": "http://registry.npmjs.org/brace/-/brace-0.11.1.tgz",

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -1318,6 +1318,14 @@
         "tslib": "^1.9.0"
       }
     },
+    "angular-custom-checkbox": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/angular-custom-checkbox/-/angular-custom-checkbox-2.0.1.tgz",
+      "integrity": "sha512-SDOljYLkSWdA357OGW4NE+4zsdLZIg8vjzdjh3ltfyN1hrHdvx81POKNHq0fKkldfG3/IwURbJCccP+UfqReaA==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -7900,6 +7908,11 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
+    },
+    "pretty-checkbox": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-checkbox/-/pretty-checkbox-3.0.3.tgz",
+      "integrity": "sha1-1JyAE6j8CO4MLW695FNGS/28Qo4="
     },
     "process": {
       "version": "0.11.10",

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -6552,6 +6552,11 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "mdi": {
+      "version": "2.2.43",
+      "resolved": "https://registry.npmjs.org/mdi/-/mdi-2.2.43.tgz",
+      "integrity": "sha512-g3m6z4303qieltUM20JL2gdsJZvoVzIzO74qa2XxZ2kg9JPwrPEAgooVhRDHZi1vvRh0gB8Dg+c9XqNdz4jcIg=="
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",

--- a/console/package.json
+++ b/console/package.json
@@ -25,6 +25,7 @@
     "@ctrl/ngx-codemirror": "^1.3.9",
     "@ng-bootstrap/ng-bootstrap": "^4.1.3",
     "ang-jsoneditor": "^1.7.1",
+    "bootstrap": "^4.3.1",
     "chart.js": "^2.8.0",
     "codemirror": "^5.41.0",
     "core-js": "^2.5.4",

--- a/console/package.json
+++ b/console/package.json
@@ -36,6 +36,7 @@
     "hammerjs": "^2.0.8",
     "jquery": "^3.3.1",
     "jsoneditor": "^5.26.3",
+    "mdi": "^2.2.43",
     "ng2-charts": "2.2.5",
     "ngx-json-viewer": "^2.4.0",
     "ngx-webstorage-service": "^4.0.1",

--- a/console/package.json
+++ b/console/package.json
@@ -25,6 +25,7 @@
     "@ctrl/ngx-codemirror": "^1.3.9",
     "@ng-bootstrap/ng-bootstrap": "^4.1.3",
     "ang-jsoneditor": "^1.7.1",
+    "angular-custom-checkbox": "^2.0.1",
     "bootstrap": "^4.3.1",
     "chart.js": "^2.8.0",
     "codemirror": "^5.41.0",
@@ -39,6 +40,7 @@
     "ngx-json-viewer": "^2.4.0",
     "ngx-webstorage-service": "^4.0.1",
     "popper.js": "^1.14.6",
+    "pretty-checkbox": "^3.0.3",
     "rxjs": "^6.2.2",
     "zone": "^0.3.4",
     "zone.js": "^0.8.26"

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.html
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.html
@@ -2,7 +2,6 @@
   <ngb-alert [type]="inactiveAlert.alertType" (close)="onAlertClosed(inactiveAlert)">{{ inactiveAlert.message }}
   </ngb-alert>
 </p>
-
 <!-- NOTE: Nodes table  -->
 <div *ngIf="(savedMongooseNodes$ | async).length; else emptyNodesTable">
   <table class="table table-bordered">
@@ -14,33 +13,30 @@
         <th scope="col" class="column-nodes-removal">Remove</th>
       </tr>
     </thead>
-
     <!-- NOTE: Nodes' table rows -->
     <tr class="component-style table-row-component" *ngFor="let savedNode of savedMongooseNodes$ | async"
-      app-nodes-set-up-table-row [runNode]="savedNode" (hasSelectedInactiveNode)="this.displayInactiveNodeAlert($event)">
+      app-nodes-set-up-table-row [runNode]="savedNode"
+      (hasSelectedInactiveNode)="this.displayInactiveNodeAlert($event)">
   </table>
 </div>
-
 <!-- NOTE: IP entering area -->
 <div class="node-input-table-wrapper">
   <div class="node-input-elements">
     <div class="node-input elem0">
       <span class="input-group-text" id="basic-addon1">IP:</span>
     </div>
-
+    <!-- NOTE: Actual input field  -->
     <div class="node-input ip-address-input">
       <input #ipAd [(ngModel)]="entredIpAddress" class="form-control mr-sm-2" type="search"
         placeholder="Enter node IP here..." aria-label="Search">
     </div>
-
+    <!-- NOTE: Add IP button -->
     <div class="node-input add-ip-btn">
       <button class="btn btn-outline-success my-2 my-sm-0" type="submit"
         (click)="onAddIpButtonClicked(ipAd.textContent)">Add</button>
     </div>
-
   </div>
 </div>
-
 <!-- NOTE: Alert if no Mongoose Run records have been found. -->
 <ng-template #emptyNodesTable>
   <div class="alert alert-secondary" role="alert">

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.html
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.html
@@ -4,13 +4,13 @@
 </p>
 <!-- NOTE: Nodes table  -->
 <div *ngIf="(savedMongooseNodes$ | async).length; else emptyNodesTable">
-  <table class="table table-bordered">
+  <table class="table">
     <thead>
       <tr>
-        <th scope="col" class="column-nodes-check">Run</th>
+        <th scope="col" class="column-nodes-check"></th>
         <th scope="col" class="column-nodes-type">Type</th>
         <th scope="col" class="column-nodes-address">Address</th>
-        <th scope="col" class="column-nodes-removal">Remove</th>
+        <th scope="col" class="column-nodes-removal"></th>
       </tr>
     </thead>
     <!-- NOTE: Nodes' table rows -->

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.html
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.html
@@ -1,6 +1,6 @@
 <th scope="row">
   <ng-container *ngIf="!this.shouldDisplayLoadingSpinner(); else loadingSpinner">
-    <div class="checkbox">
+    <div class="checkbox node-selection-element ">
       <!-- NOTE: Importing pretty-checkbox both CSS and SCSS is mandatory to use ngx-checkbox -->
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pretty-checkbox@3.0/dist/pretty-checkbox.min.css"
         crossorigin="anonymous">
@@ -34,7 +34,7 @@
 </td>
 <!-- NOTE: Loading spinner template. -->
 <ng-template #loadingSpinner>
-  <div class="spinner-border text-success" role="status">
+  <div class="spinner-border text-success node-selection-element " role="status">
     <span class="sr-only"></span>
   </div>
 </ng-template>

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.html
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.html
@@ -1,9 +1,10 @@
 <th scope="row">
   <ng-container *ngIf="!this.shouldDisplayLoadingSpinner(); else loadingSpinner">
     <div class="checkbox">
-      <input type="checkbox" id="{{ runNode.getResourceLocation() }}" class="custom-control-input"
+      <input #checkboxInput type="checkbox" id="{{ runNode.getResourceLocation() }}" class="custom-control-input"
         style="visibility: hidden;" (click)="onRunNodeSelect(runNode)">
-      <label for="{{ runNode.getResourceLocation() }}" class="custom-control-label"></label>
+      <label #checkboxLabel for="{{ runNode.getResourceLocation() }}" class="custom-control-label"
+        ></label>
     </div>
   </ng-container>
 </th>
@@ -36,6 +37,6 @@
 <!-- NOTE: Loading spinner template. -->
 <ng-template #loadingSpinner>
   <div class="spinner-border text-success" role="status">
-      <span class="sr-only"></span>
+    <span class="sr-only"></span>
   </div>
 </ng-template>

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.html
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.html
@@ -4,12 +4,11 @@
       <!-- NOTE: Importing pretty-checkbox both CSS and SCSS is mandatory to use ngx-checkbox -->
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pretty-checkbox@3.0/dist/pretty-checkbox.min.css"
         crossorigin="anonymous">
-      <ngx-checkbox [configuration]="configurationCustom" [(ngModel)]="isSelected" name="isSelected"
+      <ngx-checkbox [configuration]="checkboxConfiguration" [(ngModel)]="isNodeSelected" name="isNodeSelected"
         (click)="onRunNodeSelect(runNode)"></ngx-checkbox>
     </div>
   </ng-container>
 </th>
-
 <td> {{ runNode.resourceType }} </td>
 <td style="white-space: nowrap;">
   <!-- NOTE: Providing a space for entry-node tag. -->

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.html
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.html
@@ -25,15 +25,13 @@
         Entry node
       </span>
     </div>
-
   </div>
-
 </td>
+<!-- NOTE: Remove button -->
 <td>
   <span class="table-remove"><button type="button" class="btn btn-danger btn-rounded btn-sm my-0"
       (click)="onRunNodeRemoveClicked(runNode)">Remove</button></span>
 </td>
-
 <!-- NOTE: Loading spinner template. -->
 <ng-template #loadingSpinner>
   <div class="spinner-border text-success" role="status">

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.html
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.html
@@ -1,15 +1,11 @@
 <th scope="row">
   <ng-container *ngIf="!this.shouldDisplayLoadingSpinner(); else loadingSpinner">
     <div class="checkbox">
+      <!-- NOTE: Importing pretty-checkbox both CSS and SCSS is mandatory to use ngx-checkbox -->
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pretty-checkbox@3.0/dist/pretty-checkbox.min.css"
         crossorigin="anonymous">
       <ngx-checkbox [configuration]="configurationCustom" [(ngModel)]="isSelected" name="isSelected"
         (click)="onRunNodeSelect(runNode)"></ngx-checkbox>
-
-      <!-- <input #checkboxInput type="checkbox" id="{{ runNode.getResourceLocation() }}" class="custom-control-input"
-        style="visibility: hidden;" (click)="onRunNodeSelect(runNode)">
-      <label #checkboxLabel for="{{ runNode.getResourceLocation() }}" class="custom-control-label"
-        ></label> -->
     </div>
   </ng-container>
 </th>

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.html
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.html
@@ -1,10 +1,15 @@
 <th scope="row">
   <ng-container *ngIf="!this.shouldDisplayLoadingSpinner(); else loadingSpinner">
     <div class="checkbox">
-      <input #checkboxInput type="checkbox" id="{{ runNode.getResourceLocation() }}" class="custom-control-input"
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pretty-checkbox@3.0/dist/pretty-checkbox.min.css"
+        crossorigin="anonymous">
+      <ngx-checkbox [configuration]="configurationCustom" [(ngModel)]="isSelected" name="isSelected"
+        (click)="onRunNodeSelect(runNode)"></ngx-checkbox>
+
+      <!-- <input #checkboxInput type="checkbox" id="{{ runNode.getResourceLocation() }}" class="custom-control-input"
         style="visibility: hidden;" (click)="onRunNodeSelect(runNode)">
       <label #checkboxLabel for="{{ runNode.getResourceLocation() }}" class="custom-control-label"
-        ></label>
+        ></label> -->
     </div>
   </ng-container>
 </th>

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.scss
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.scss
@@ -8,7 +8,7 @@ $CHECKBOX_SELECTED_COLOR: #fff;
 $CHECKBOX_SELECTED_BORDER_COLOR: #5cb85c;
 
 .checkbox:not(last-of-type) {
-  // NOTE: Cirlle
+  // NOTE: Circle
   label {
     background-color: pink;
     position: relative;

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.scss
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.scss
@@ -1,3 +1,4 @@
+// NOTE: Importing pretty checkbox in order to make angular-custom-checkbox work correctly
 @import '~pretty-checkbox/src/pretty-checkbox.scss';
 
 // NOTE: Node select checkbox.
@@ -8,67 +9,6 @@ $CHECKBOX_CHECK_MARK_COLOR: #5cb85c;
 
 $CHECKBOX_SELECTED_COLOR: #fff;
 $CHECKBOX_SELECTED_BORDER_COLOR: #5cb85c;
-
-// .checkbox:not(last-of-type) {
-//   // NOTE: Circle
-//   label {
-//     background-color: pink;
-//     position: relative;
-//     display: block;
-//     margin: 0 auto;
-//     top: 0;
-//     width: $CHECKBOX_DIAMETER;
-//     height: $CHECKBOX_DIAMETER;
-//     // NOTE: Unselected circle configuration
-//     background-color: $CHECKBOX_BACKGROUND_COLOR;
-//     border: 1px solid $CHECKBOX_SELECTED_BORDER_COLOR;
-//     border-radius: 50%;
-//     cursor: pointer;
-//     transition: background-color 300ms ease, colour 300ms ease, box-shadow 300ms ease;
-
-//     // NOTE: Checkmark
-//     &:after {
-//       content: "";
-//       position: absolute;
-//       // NOTE: Constructing checkmark
-//       width: 50%;
-//       height: 34%;
-//       top: 33%;
-//       left: 23%;
-//       opacity: 0;
-//       border-left: 2px solid $CHECKBOX_CHECK_MARK_COLOR;
-//       border-bottom: 2px solid $CHECKBOX_CHECK_MARK_COLOR;
-//       // NOTE: Checkmark is a rotated by 45 degrees rectangle.
-//       transform: rotate(-45deg);
-//       transition: opacity 300ms ease;
-//     }
-
-//     &:before {
-//       visibility: hidden;
-//     }
-//   }
-
-//   input {
-//     visibility: hidden;
-
-//     // NOTE: Checkbox selected state background configuration
-//     &:checked + label {
-//       background-color: $CHECKBOX_BACKGROUND_COLOR-selected;
-//       border-color: $CHECKBOX_BACKGROUND_COLOR-selected;
-//       // NOTE: Selected checkbox checkmark's state
-//       &:after {
-//         opacity: 1;
-//       }
-//     }
-//   }
-
-//   input {
-//     &:checked + label {
-//       background-color: ($CHECKBOX_SELECTED_COLOR);
-//       border-color: ($CHECKBOX_SELECTED_BORDER_COLOR);
-//     }
-//   }
-// }
 
 #entry-node-tag {
   border-color: $CHECKBOX_BACKGROUND_COLOR;

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.scss
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.scss
@@ -1,3 +1,5 @@
+@import '~pretty-checkbox/src/pretty-checkbox.scss';
+
 // NOTE: Node select checkbox.
 $CHECKBOX_DIAMETER: 25px;
 $CHECKBOX_BACKGROUND_COLOR-selected: #356cd2;
@@ -7,66 +9,66 @@ $CHECKBOX_CHECK_MARK_COLOR: #5cb85c;
 $CHECKBOX_SELECTED_COLOR: #fff;
 $CHECKBOX_SELECTED_BORDER_COLOR: #5cb85c;
 
-.checkbox:not(last-of-type) {
-  // NOTE: Circle
-  label {
-    background-color: pink;
-    position: relative;
-    display: block;
-    margin: 0 auto;
-    top: 0;
-    width: $CHECKBOX_DIAMETER;
-    height: $CHECKBOX_DIAMETER;
-    // NOTE: Unselected circle configuration
-    background-color: $CHECKBOX_BACKGROUND_COLOR;
-    border: 1px solid $CHECKBOX_SELECTED_BORDER_COLOR;
-    border-radius: 50%;
-    cursor: pointer;
-    transition: background-color 300ms ease, colour 300ms ease, box-shadow 300ms ease;
+// .checkbox:not(last-of-type) {
+//   // NOTE: Circle
+//   label {
+//     background-color: pink;
+//     position: relative;
+//     display: block;
+//     margin: 0 auto;
+//     top: 0;
+//     width: $CHECKBOX_DIAMETER;
+//     height: $CHECKBOX_DIAMETER;
+//     // NOTE: Unselected circle configuration
+//     background-color: $CHECKBOX_BACKGROUND_COLOR;
+//     border: 1px solid $CHECKBOX_SELECTED_BORDER_COLOR;
+//     border-radius: 50%;
+//     cursor: pointer;
+//     transition: background-color 300ms ease, colour 300ms ease, box-shadow 300ms ease;
 
-    // NOTE: Checkmark
-    &:after {
-      content: "";
-      position: absolute;
-      // NOTE: Constructing checkmark
-      width: 50%;
-      height: 34%;
-      top: 33%;
-      left: 23%;
-      opacity: 0;
-      border-left: 2px solid $CHECKBOX_CHECK_MARK_COLOR;
-      border-bottom: 2px solid $CHECKBOX_CHECK_MARK_COLOR;
-      // NOTE: Checkmark is a rotated by 45 degrees rectangle.
-      transform: rotate(-45deg);
-      transition: opacity 300ms ease;
-    }
+//     // NOTE: Checkmark
+//     &:after {
+//       content: "";
+//       position: absolute;
+//       // NOTE: Constructing checkmark
+//       width: 50%;
+//       height: 34%;
+//       top: 33%;
+//       left: 23%;
+//       opacity: 0;
+//       border-left: 2px solid $CHECKBOX_CHECK_MARK_COLOR;
+//       border-bottom: 2px solid $CHECKBOX_CHECK_MARK_COLOR;
+//       // NOTE: Checkmark is a rotated by 45 degrees rectangle.
+//       transform: rotate(-45deg);
+//       transition: opacity 300ms ease;
+//     }
 
-    &:before {
-      visibility: hidden;
-    }
-  }
+//     &:before {
+//       visibility: hidden;
+//     }
+//   }
 
-  input {
-    visibility: hidden;
+//   input {
+//     visibility: hidden;
 
-    // NOTE: Checkbox selected state background configuration
-    &:checked + label {
-      background-color: $CHECKBOX_BACKGROUND_COLOR-selected;
-      border-color: $CHECKBOX_BACKGROUND_COLOR-selected;
-      // NOTE: Selected checkbox checkmark's state
-      &:after {
-        opacity: 1;
-      }
-    }
-  }
+//     // NOTE: Checkbox selected state background configuration
+//     &:checked + label {
+//       background-color: $CHECKBOX_BACKGROUND_COLOR-selected;
+//       border-color: $CHECKBOX_BACKGROUND_COLOR-selected;
+//       // NOTE: Selected checkbox checkmark's state
+//       &:after {
+//         opacity: 1;
+//       }
+//     }
+//   }
 
-  input {
-    &:checked + label {
-      background-color: ($CHECKBOX_SELECTED_COLOR);
-      border-color: ($CHECKBOX_SELECTED_BORDER_COLOR);
-    }
-  }
-}
+//   input {
+//     &:checked + label {
+//       background-color: ($CHECKBOX_SELECTED_COLOR);
+//       border-color: ($CHECKBOX_SELECTED_BORDER_COLOR);
+//     }
+//   }
+// }
 
 #entry-node-tag {
   border-color: $CHECKBOX_BACKGROUND_COLOR;

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.scss
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.scss
@@ -1,5 +1,5 @@
 // NOTE: Importing pretty checkbox in order to make angular-custom-checkbox work correctly
-@import '~pretty-checkbox/src/pretty-checkbox.scss';
+@import "~pretty-checkbox/src/pretty-checkbox.scss";
 
 // NOTE: Node select checkbox.
 $CHECKBOX_DIAMETER: 25px;
@@ -7,11 +7,13 @@ $CHECKBOX_BACKGROUND_COLOR-selected: #356cd2;
 $CHECKBOX_BACKGROUND_COLOR: #c9f6c9;
 $CHECKBOX_CHECK_MARK_COLOR: #5cb85c;
 
-$CHECKBOX_SELECTED_COLOR: #fff;
-$CHECKBOX_SELECTED_BORDER_COLOR: #5cb85c;
-
 #entry-node-tag {
   border-color: $CHECKBOX_BACKGROUND_COLOR;
   border: 1px $CHECKBOX_BACKGROUND_COLOR solid;
   font-weight: normal;
+}
+
+.node-selection-element {
+  width: $CHECKBOX_DIAMETER;
+  height: $CHECKBOX_DIAMETER;
 }

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.ts
@@ -32,8 +32,8 @@ export class NodesSetUpTableRowComponent implements OnInit {
   private isNodeInValidationProcess: boolean = false;
   private slaveNodesSubscription: Subscription = new Subscription();
 
-  isSelected: boolean = false;
-  configurationCustom: CustomCheckBoxModel = new CustomCheckBoxModel();
+  isNodeSelected: boolean = false;
+  checkboxConfiguration: CustomCheckBoxModel = new CustomCheckBoxModel();
 
   // MARK: - Lifecycle 
   constructor(private mongooseSetUpService: MongooseSetUpService,
@@ -41,11 +41,9 @@ export class NodesSetUpTableRowComponent implements OnInit {
     private localStorageService: LocalStorageService) { }
 
   ngOnInit() {
-    this.configurationCustom.color = 'p-success';
-    // this.configurationCustom.colorHex = '#F500FF';
-    // this.configurationCustom.colorInside = '#FFF' //or 'white';
-    this.configurationCustom.rounded = true;
-    this.configurationCustom.icon = 'fa fa-check';
+    this.checkboxConfiguration.color = 'p-success';
+    this.checkboxConfiguration.rounded = true;
+    this.checkboxConfiguration.icon = 'fa fa-check';
   }
 
   // MARK: - Public
@@ -55,9 +53,6 @@ export class NodesSetUpTableRowComponent implements OnInit {
    * @param selectedNode instance of selected Mongoose node.
    */
   public onRunNodeSelect(selectedNode: MongooseRunNode) {
-    // console.log(`Checkbox input value: ${this.checkboxInput.nativeElement.value}, whole JSON is: ${JSON.stringify(this.checkboxInput.nativeElement)}`);
-    // console.log(`Checkbox label value: ${this.checkboxLabel.nativeElement.value}`);
-
     let isNodeLocatedByIp: boolean = (selectedNode.getResourceType() == ResourceLocatorType.IP);
     // NOTE: Add noode if check mark has been set, remove if unset    
     let hasNodeBeenSelected: boolean = this.mongooseSetUpService.isNodeExist(selectedNode);
@@ -75,10 +70,12 @@ export class NodesSetUpTableRowComponent implements OnInit {
           map(
             // NOTE: Node's validation process.
             (isNodeActive: boolean) => {
-              this.isSelected = isNodeActive;
-
+              this.isNodeSelected = true;
               if (!isNodeActive) {
                 // NOTE: Handle run node inactivity.
+                this.checkboxConfiguration.color = "p-danger";
+                this.checkboxConfiguration.icon = 'fa fa-exclamation-circle';
+
                 this.hasSelectedInactiveNode.emit(selectedNode);
                 return;
               }

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.ts
@@ -7,6 +7,8 @@ import { MongooseStoredRunNode } from 'src/app/core/services/local-storage-servi
 import { Subscription } from 'rxjs';
 import { ResourceLocatorType } from 'src/app/core/models/address-type';
 import { map } from 'rxjs/operators';
+import { CustomCheckBoxModel } from 'angular-custom-checkbox';
+
 
 @Component({
   selector: '[app-nodes-set-up-table-row]',
@@ -25,8 +27,8 @@ export class NodesSetUpTableRowComponent implements OnInit {
    */
   @Output() hasSelectedInactiveNode: EventEmitter<MongooseRunNode> = new EventEmitter<MongooseRunNode>();
 
-  @ViewChild(`checkboxInput`) checkboxInput;
-  @ViewChild(`checkboxLabel`) checkboxLabel;
+  // @ViewChild(`checkboxInput`) checkboxInput;
+  // @ViewChild(`checkboxLabel`) checkboxLabel;
 
 
   private readonly ENTRY_NODE_CUSTOM_CLASS: string = "entry-node";
@@ -34,12 +36,21 @@ export class NodesSetUpTableRowComponent implements OnInit {
   private isNodeInValidationProcess: boolean = false;
   private slaveNodesSubscription: Subscription = new Subscription();
 
+  isSelected: boolean = false;
+  configurationCustom: CustomCheckBoxModel = new CustomCheckBoxModel();
+
   // MARK: - Lifecycle 
   constructor(private mongooseSetUpService: MongooseSetUpService,
     private mongooseDataSharedService: MongooseDataSharedServiceService,
     private localStorageService: LocalStorageService) { }
 
-  ngOnInit() { }
+  ngOnInit() {
+    this.configurationCustom.color = 'p-success';
+    this.configurationCustom.colorHex = '#F500FF';
+    this.configurationCustom.colorInside = '#FFF' //or 'white';
+    this.configurationCustom.rounded = true;
+    this.configurationCustom.icon = 'mdi mdi-check';
+  }
 
   // MARK: - Public
 
@@ -48,8 +59,8 @@ export class NodesSetUpTableRowComponent implements OnInit {
    * @param selectedNode instance of selected Mongoose node.
    */
   public onRunNodeSelect(selectedNode: MongooseRunNode) {
-    console.log(`Checkbox input value: ${this.checkboxInput.nativeElement.value}, whole JSON is: ${JSON.stringify(this.checkboxInput.nativeElement)}`);
-    console.log(`Checkbox label value: ${this.checkboxLabel.nativeElement.value}`);
+    // console.log(`Checkbox input value: ${this.checkboxInput.nativeElement.value}, whole JSON is: ${JSON.stringify(this.checkboxInput.nativeElement)}`);
+    // console.log(`Checkbox label value: ${this.checkboxLabel.nativeElement.value}`);
 
     let isNodeLocatedByIp: boolean = (selectedNode.getResourceType() == ResourceLocatorType.IP);
     // NOTE: Add noode if check mark has been set, remove if unset    
@@ -68,6 +79,8 @@ export class NodesSetUpTableRowComponent implements OnInit {
           map(
             // NOTE: Node's validation process.
             (isNodeActive: boolean) => {
+              this.isSelected = isNodeActive;
+
               if (!isNodeActive) {
                 // NOTE: Handle run node inactivity.
                 this.hasSelectedInactiveNode.emit(selectedNode);

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.ts
@@ -41,9 +41,7 @@ export class NodesSetUpTableRowComponent implements OnInit {
     private localStorageService: LocalStorageService) { }
 
   ngOnInit() {
-    this.checkboxConfiguration.color = 'p-success';
     this.checkboxConfiguration.rounded = true;
-    this.checkboxConfiguration.icon = 'fa fa-check';
   }
 
   // MARK: - Public
@@ -74,11 +72,12 @@ export class NodesSetUpTableRowComponent implements OnInit {
               if (!isNodeActive) {
                 // NOTE: Handle run node inactivity.
                 this.checkboxConfiguration.color = "p-danger";
-                this.checkboxConfiguration.icon = 'fa fa-exclamation-circle';
-
+                this.checkboxConfiguration.icon = 'fa fa-refresh';
                 this.hasSelectedInactiveNode.emit(selectedNode);
                 return;
               }
+              this.checkboxConfiguration.color = "p-success";
+              this.checkboxConfiguration.icon = 'fa fa-check';
               this.mongooseSetUpService.addNode(selectedNode);
             },
           )

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.ts
@@ -27,10 +27,6 @@ export class NodesSetUpTableRowComponent implements OnInit {
    */
   @Output() hasSelectedInactiveNode: EventEmitter<MongooseRunNode> = new EventEmitter<MongooseRunNode>();
 
-  // @ViewChild(`checkboxInput`) checkboxInput;
-  // @ViewChild(`checkboxLabel`) checkboxLabel;
-
-
   private readonly ENTRY_NODE_CUSTOM_CLASS: string = "entry-node";
 
   private isNodeInValidationProcess: boolean = false;
@@ -46,10 +42,10 @@ export class NodesSetUpTableRowComponent implements OnInit {
 
   ngOnInit() {
     this.configurationCustom.color = 'p-success';
-    this.configurationCustom.colorHex = '#F500FF';
-    this.configurationCustom.colorInside = '#FFF' //or 'white';
+    // this.configurationCustom.colorHex = '#F500FF';
+    // this.configurationCustom.colorInside = '#FFF' //or 'white';
     this.configurationCustom.rounded = true;
-    this.configurationCustom.icon = 'mdi mdi-check';
+    this.configurationCustom.icon = 'fa fa-check';
   }
 
   // MARK: - Public

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter, ViewChild } from '@angular/core';
 import { MongooseRunNode } from 'src/app/core/models/mongoose-run-node.model';
 import { MongooseSetUpService } from 'src/app/core/services/mongoose-set-up-service/mongoose-set-up.service';
 import { MongooseDataSharedServiceService } from 'src/app/core/services/mongoose-data-shared-service/mongoose-data-shared-service.service';
@@ -25,6 +25,10 @@ export class NodesSetUpTableRowComponent implements OnInit {
    */
   @Output() hasSelectedInactiveNode: EventEmitter<MongooseRunNode> = new EventEmitter<MongooseRunNode>();
 
+  @ViewChild(`checkboxInput`) checkboxInput;
+  @ViewChild(`checkboxLabel`) checkboxLabel;
+
+
   private readonly ENTRY_NODE_CUSTOM_CLASS: string = "entry-node";
 
   private isNodeInValidationProcess: boolean = false;
@@ -44,6 +48,9 @@ export class NodesSetUpTableRowComponent implements OnInit {
    * @param selectedNode instance of selected Mongoose node.
    */
   public onRunNodeSelect(selectedNode: MongooseRunNode) {
+    console.log(`Checkbox input value: ${this.checkboxInput.nativeElement.value}, whole JSON is: ${JSON.stringify(this.checkboxInput.nativeElement)}`);
+    console.log(`Checkbox label value: ${this.checkboxLabel.nativeElement.value}`);
+
     let isNodeLocatedByIp: boolean = (selectedNode.getResourceType() == ResourceLocatorType.IP);
     // NOTE: Add noode if check mark has been set, remove if unset    
     let hasNodeBeenSelected: boolean = this.mongooseSetUpService.isNodeExist(selectedNode);
@@ -64,7 +71,6 @@ export class NodesSetUpTableRowComponent implements OnInit {
               if (!isNodeActive) {
                 // NOTE: Handle run node inactivity.
                 this.hasSelectedInactiveNode.emit(selectedNode);
-                this.isNodeInValidationProcess = false;
                 return;
               }
               this.mongooseSetUpService.addNode(selectedNode);

--- a/console/src/app/modules/mongoose-set-up-module/mongoose-set-up-module.module.ts
+++ b/console/src/app/modules/mongoose-set-up-module/mongoose-set-up-module.module.ts
@@ -16,6 +16,7 @@ import { DateFormatPipe } from "src/app/common/date-format-pipe";
 import { LocalStorageService } from "src/app/core/services/local-storage-service/local-storage.service";
 import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
 import { NodesSetUpTableRowComponent } from "./components/mongoose-set-up/set-up-steps/nodes/set-up-table-row/nodes-set-up-table-row.component";
+import { CustomCheckboxModule } from 'angular-custom-checkbox';
 
 
 @NgModule({
@@ -26,7 +27,9 @@ import { NodesSetUpTableRowComponent } from "./components/mongoose-set-up/set-up
     // NOTE: Dependencies
     NgJsonEditorModule,
     CodemirrorModule,
-    NgbModule
+    NgbModule,
+    CustomCheckboxModule,
+    FormsModule
   ],
   declarations: [
     MongooseSetUpComponent,

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -7,3 +7,7 @@
 
 /* NOTE: JsonEditor style for displaying json as tree  */
 @import "~jsoneditor/dist/jsoneditor.min.css";
+
+/* NOTE: Custom fonts */
+@import "~bootstrap/dist/css/bootstrap.css";
+@import "~font-awesome/css/font-awesome.css";


### PR DESCRIPTION
**Current environment**
Checkboxes within the nodes screen are drawn using SCSS variables. Thus, they can't be drawn from the code in a runtime because the DOM doesn't include them. 

**Purpose**
Replacing SCSS-drawn elements with custom module, which elements will be included into the DOM, will allow controlling of checkboxes drawing behaviour from the code.

Angular custom checkbox reference: https://github.com/rafaelblink/angular-custom-checkbox