### PR TITLE
[GUI-184] Fix issue with HTTP / HTTPs addresses.

### DIFF
--- a/console/src/app/common/HttpUtils.ts
+++ b/console/src/app/common/HttpUtils.ts
@@ -78,13 +78,21 @@ export class HttpUtils {
     }
 
     /**
-     * Prunes HTTP ("http://") prefix from given address.
+     * Prunes HTTP ("http://") or HTTPS ("https://") prefixes from given address.
      * @param address IPv4 address.
      * @return address without HTTP prefix.
      */
     public static pruneHttpPrefixFromAddress(address: string): string {
         const httpPrefix: string = Constants.Http.HTTP_PREFIX;
+        const httpsPrefix: string = Constants.Http.HTTPS_PREFIX;
         const emptyValue: string = "";
-        return address.replace(httpPrefix, emptyValue);
+        if (address.includes(httpPrefix)) {
+            // NOTE: Handling HTTP-prefixed addresses
+            return address.replace(httpPrefix, emptyValue);
+        } else if (address.includes(httpsPrefix)) {
+            // NOTE: Handling HTTPS-prefixed addresses
+            return address.replace(httpsPrefix, emptyValue);
+        }
+        return address;
     }
 }

--- a/console/src/app/common/HttpUtils.ts
+++ b/console/src/app/common/HttpUtils.ts
@@ -86,6 +86,8 @@ export class HttpUtils {
         const httpPrefix: string = Constants.Http.HTTP_PREFIX;
         const httpsPrefix: string = Constants.Http.HTTPS_PREFIX;
         const emptyValue: string = "";
+        
+        // NOTE: Prefix pruning logic 
         if (address.includes(httpPrefix)) {
             // NOTE: Handling HTTP-prefixed addresses
             return address.replace(httpPrefix, emptyValue);

--- a/console/src/app/common/constants.ts
+++ b/console/src/app/common/constants.ts
@@ -57,7 +57,8 @@ export namespace Constants {
             headers: new HttpHeaders({ 'Content-Type': 'application/x-www-form-urlencoded' })
         }
 
-        static readonly HTTP_PREFIX = "http://";
+        static readonly HTTP_PREFIX: string = "http://";
+        static readonly HTTPS_PREFIX: string = "https://";
     }
 
     export class HttpStatus {

--- a/console/src/app/modules/app-module/components/common/prometheus-error/prometheus-error.component.ts
+++ b/console/src/app/modules/app-module/components/common/prometheus-error/prometheus-error.component.ts
@@ -112,20 +112,24 @@ export class PrometheusErrorComponent implements OnInit, OnDestroy {
    */
   private tryToLoadPrometheus(prometheusAddress: string) {
     this.isLoadingInProgress = true;
+    // NOTE: Pruning prefixes in order to exclude invalid target URl and any errors ...
+    // ... within services.
+    const prometheusAddressWithoutPrefixes: string = HttpUtils.pruneHttpPrefixFromAddress(prometheusAddress);
+    
     this.activeSubscriptions.add(
-      this.prometheusApiService.isAvailable(prometheusAddress).subscribe(
+      this.prometheusApiService.isAvailable(prometheusAddressWithoutPrefixes).subscribe(
         (isPrometheusAvailable: boolean) => {
           this.isLoadingInProgress = false;
-          this.prometheusResourceLocation = prometheusAddress;
+          this.prometheusResourceLocation = prometheusAddressWithoutPrefixes;
           if (!isPrometheusAvailable) {
-            console.error(`Prometheus is not available on ${prometheusAddress}`);
+            console.error(`Prometheus is not available on ${prometheusAddressWithoutPrefixes}`);
             return;
           }
-          console.log(`Prometheus has successfully loaded on ${prometheusAddress}.`);
+          console.log(`Prometheus has successfully loaded on ${prometheusAddressWithoutPrefixes}.`);
           // NOTE: Saving Prometheus' address if true.
-          this.localStorageService.savePrometheusHostAddress(prometheusAddress);
+          this.localStorageService.savePrometheusHostAddress(prometheusAddressWithoutPrefixes);
           // NOTE: Updating Prometheus' address.
-          this.prometheusApiService.setHostIpAddress(prometheusAddress);
+          this.prometheusApiService.setHostIpAddress(prometheusAddressWithoutPrefixes);
           this.onPrometheusLoad.emit();
         }
       )

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.ts
@@ -63,8 +63,10 @@ export class NodesComponent implements OnInit, OnDestroy {
    */
   public onAddIpButtonClicked(): void {
     // NOTE: trimming accident whitespaces
-    this.entredIpAddress = this.entredIpAddress.replace(/\s/g, "");
-
+    const allWhitespacesRegex: RegExp = /\s/g;
+    this.entredIpAddress = this.entredIpAddress.replace(allWhitespacesRegex, "");
+    console.log(`[${NodesComponent.name}] Processing entered IPv4 address: "${this.entredIpAddress}"`);
+    
     const savingNodeAddress: string = this.entredIpAddress;
     if (!HttpUtils.isIpAddressValid(savingNodeAddress)) {
       if (HttpUtils.matchesIpv4AddressWithoutPort(savingNodeAddress)) {
@@ -75,7 +77,9 @@ export class NodesComponent implements OnInit, OnDestroy {
       }
     }
 
-    let newMongooseNode = new MongooseRunNode(this.entredIpAddress);
+    const processedMongooseNodeAddress: string = HttpUtils.pruneHttpPrefixFromAddress(this.entredIpAddress);
+
+    let newMongooseNode = new MongooseRunNode(processedMongooseNodeAddress);
     try {
       const savingNodeAddress: string = newMongooseNode.getResourceLocation();
 


### PR DESCRIPTION
**Start command/request**
Add Mongoose's / Prometheus' address containing HTTP / HTTPS prefix.

**Expected behaviour**
Expect the UI to be working correctly with those addresses.

**Observed behaviour**
It passes the validation, but doesn't work.

Related JIRA's task: https://mongoose-issues.atlassian.net/projects/GUI/issues/GUI-184