### PR TITLE
[GUI-177] Change placeholders & update related UI.

### DIFF
--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/incative-node-alert.interface.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/incative-node-alert.interface.ts
@@ -1,11 +1,12 @@
 import { MongooseRunNode } from "src/app/core/models/mongoose-run-node.model";
+import { NodeSetUpAlert } from "./node-setup-alert.type";
 
 export class InactiveNodeAlert { 
     alertType: string = "danger";
     message: string;
     mongooseNode: MongooseRunNode; 
 
-    constructor( displayingMessage: string, mongooseNode: MongooseRunNode) { 
+    constructor(displayingMessage: string, mongooseNode: MongooseRunNode, type: NodeSetUpAlert) { 
         this.message = displayingMessage;
         this.mongooseNode = mongooseNode; 
     }

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/node-alert.interface.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/node-alert.interface.ts
@@ -1,12 +1,12 @@
 import { MongooseRunNode } from "src/app/core/models/mongoose-run-node.model";
-import { NodeSetUpAlert } from "./node-setup-alert.type";
+import { NodeSetUpAlertType } from "./node-setup-alert.type";
 
-export class InactiveNodeAlert { 
+export class NodeAlert { 
     alertType: string = "danger";
     message: string;
     mongooseNode: MongooseRunNode; 
 
-    constructor(displayingMessage: string, mongooseNode: MongooseRunNode, type: NodeSetUpAlert) { 
+    constructor(displayingMessage: string, mongooseNode: MongooseRunNode, type: NodeSetUpAlertType) { 
         this.message = displayingMessage;
         this.mongooseNode = mongooseNode; 
     }

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/node-alert.interface.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/node-alert.interface.ts
@@ -1,13 +1,24 @@
 import { MongooseRunNode } from "src/app/core/models/mongoose-run-node.model";
 import { NodeSetUpAlertType } from "./node-setup-alert.type";
 
-export class NodeAlert { 
-    alertType: string = "danger";
-    message: string;
-    mongooseNode: MongooseRunNode; 
+export class NodeAlert {
 
-    constructor(displayingMessage: string, mongooseNode: MongooseRunNode, type: NodeSetUpAlertType) { 
+    /**
+     * @param mongooseNode node that caused an alert to appear.
+     * @param message displays basic alert message.
+     */
+
+    public message: string;
+    public mongooseNode: MongooseRunNode;
+
+    /**
+     * @param alertType determines type (appearence) of alert.
+     */
+    private alertType: string = "danger";
+
+
+    constructor(displayingMessage: string, mongooseNode: MongooseRunNode, type: NodeSetUpAlertType) {
         this.message = displayingMessage;
-        this.mongooseNode = mongooseNode; 
+        this.mongooseNode = mongooseNode;
     }
 }

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/node-setup-alert.type.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/node-setup-alert.type.ts
@@ -1,4 +1,4 @@
-export enum NodeSetUpAlert { 
+export enum NodeSetUpAlertType { 
     ERROR = "error",
     WARNING = "warning"
 }

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/node-setup-alert.type.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/node-setup-alert.type.ts
@@ -1,0 +1,4 @@
+export enum NodeSetUpAlert { 
+    ERROR = "error",
+    WARNING = "warning"
+}

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.html
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.html
@@ -1,5 +1,6 @@
-<p *ngFor="let inactiveAlert of inactiveNodeAlerts">
-  <ngb-alert [type]="inactiveAlert.alertType" (close)="onAlertClosed(inactiveAlert)">{{ inactiveAlert.message }}
+<!-- NOTE: Alerts that are caused because of a particular node selection. -->
+<p *ngFor="let nodeAlert of nodeAlerts">
+  <ngb-alert [type]="nodeAlert.alertType" (close)="onAlertClosed(nodeAlert)">{{ nodeAlert.message }}
   </ngb-alert>
 </p>
 <!-- NOTE: Nodes table  -->
@@ -17,7 +18,7 @@
     <!-- NOTE: Nodes' table rows -->
     <tr class="component-style table-row-component" *ngFor="let savedNode of savedMongooseNodes$ | async"
       app-nodes-set-up-table-row [runNode]="savedNode"
-      (hasSelectedInactiveNode)="this.displayInactiveNodeAlert($event)">
+      (hasSelectedInactiveNode)="this.displayNodeAlert($event)">
   </table>
 </div>
 <!-- NOTE: IP entering area -->

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.ts
@@ -111,9 +111,10 @@ export class NodesComponent implements OnInit, OnDestroy {
 
   /**
  * Displays alert on top of the screen notifying that inactive node is selected.
- * @param inactiveNode inactive node instance.
+ * @param selectedNodeInfo instance of node that causes alert to appear.
+ * @param type type of appearing alert. Error by default.
  */
-  public displayNodeAlert(selectedNodeInfo: MongooseRunNode, type: NodeSetUpAlertType) {
+  public displayNodeAlert(selectedNodeInfo: MongooseRunNode, type: NodeSetUpAlertType = NodeSetUpAlertType.ERROR) {
     // NOTE: Display error if Mongoose node is not activy. Don't added it to ...
     // ... the configuration thought. 
     let nodeAlert = new NodeAlert(`selected node ${selectedNodeInfo.getResourceLocation()} is not active`, selectedNodeInfo, type);

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.ts
@@ -17,7 +17,7 @@ import { HttpUtils } from 'src/app/common/HttpUtils';
 })
 export class NodesComponent implements OnInit, OnDestroy {
 
-  private readonly IP_DEFAULT_PORT: number = 9999;
+  private readonly IP_DEFAULT_PORT: number = 9991;
 
   public runNode: MongooseRunNode;
 

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.ts
@@ -4,10 +4,11 @@ import { ControlApiService } from 'src/app/core/services/control-api/control-api
 import { Subscription, Observable } from 'rxjs';
 import { MongooseRunNode } from 'src/app/core/models/mongoose-run-node.model';
 import { MongooseDataSharedServiceService } from 'src/app/core/services/mongoose-data-shared-service/mongoose-data-shared-service.service';
-import { InactiveNodeAlert } from './incative-node-alert.interface';
 import { LocalStorageService } from 'src/app/core/services/local-storage-service/local-storage.service';
 import { map } from 'rxjs/operators';
 import { HttpUtils } from 'src/app/common/HttpUtils';
+import { NodeAlert } from './node-alert.interface';
+import { NodeSetUpAlertType } from './node-setup-alert.type';
 
 @Component({
   selector: 'app-nodes',
@@ -22,7 +23,7 @@ export class NodesComponent implements OnInit, OnDestroy {
   public runNode: MongooseRunNode;
 
   public savedMongooseNodes$: Observable<MongooseRunNode[]> = new Observable<MongooseRunNode[]>();
-  public inactiveNodeAlerts: InactiveNodeAlert[] = [];
+  public nodeAlerts: NodeAlert[] = [];
   public displayingIpAddresses: String[] = this.controlApiService.mongooseSlaveNodes;
   public entredIpAddress = '';
   public nodeConfig: any = null;
@@ -102,9 +103,9 @@ export class NodesComponent implements OnInit, OnDestroy {
     }
   }
 
-  public onAlertClosed(closedAlert: InactiveNodeAlert) {
+  public onAlertClosed(closedAlert: NodeAlert) {
     let closedAlertIndex = this.getAlertIndex(closedAlert);
-    this.inactiveNodeAlerts.splice(closedAlertIndex, 1);
+    this.nodeAlerts.splice(closedAlertIndex, 1);
   }
 
 
@@ -112,27 +113,27 @@ export class NodesComponent implements OnInit, OnDestroy {
  * Displays alert on top of the screen notifying that inactive node is selected.
  * @param inactiveNode inactive node instance.
  */
-  public displayInactiveNodeAlert(selectedNodeInfo: MongooseRunNode) {
+  public displayNodeAlert(selectedNodeInfo: MongooseRunNode, type: NodeSetUpAlertType) {
     // NOTE: Display error if Mongoose node is not activy. Don't added it to ...
     // ... the configuration thought. 
-    let inactiveNodeAlert = new InactiveNodeAlert(`selected node ${selectedNodeInfo.getResourceLocation()} is not active`, selectedNodeInfo);
+    let nodeAlert = new NodeAlert(`selected node ${selectedNodeInfo.getResourceLocation()} is not active`, selectedNodeInfo, type);
 
     // NOTE: Finding alert by message in alerts array
-    let alertIndex = this.getAlertIndex(inactiveNodeAlert);
+    let alertIndex = this.getAlertIndex(nodeAlert);
     let isAlertExist: boolean = (alertIndex >= 0);
 
     if (!isAlertExist) {
-      this.inactiveNodeAlerts.push(inactiveNodeAlert);
+      this.nodeAlerts.push(nodeAlert);
     }
     return;
   }
 
   // MARK: - Private
 
-  private getAlertIndex(inactiveNodeAlert: InactiveNodeAlert): number {
-    return (this.inactiveNodeAlerts.findIndex(
-      (alert: InactiveNodeAlert) => {
-        return (alert.message == inactiveNodeAlert.message);
+  private getAlertIndex(nodeAlert: NodeAlert): number {
+    return (this.nodeAlerts.findIndex(
+      (alert: NodeAlert) => {
+        return (alert.message == nodeAlert.message);
       }));
   }
 


### PR DESCRIPTION
**Current environment**
Some placeholders are taking a place and, sometimes, they're invalid. Some of them are:
“localhost:9999” @ nodes screen;
“Details” block appears on a browser’s alert in case Mongoose launch fails;
“Prometheus is not available on…” alert; 
 
**Desired environment**
Remove all invalid and unnecessary placeholders.

Related JIRA's: https://mongoose-issues.atlassian.net/projects/GUI/issues/GUI-177